### PR TITLE
Add MUD-style resume site with FastAPI backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.log
+pytest_cache/

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,73 @@
+import json
+import uuid
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+
+# Load room data
+ROOMS_PATH = Path(__file__).parent / "rooms.json"
+with ROOMS_PATH.open() as f:
+    rooms = json.load(f)
+
+# Serve static files
+STATIC_DIR = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+# In-memory session store
+sessions: dict[str, dict] = {}
+
+def describe_room(key: str) -> str:
+    room = rooms[key]
+    exits = ", ".join(room.get("exits", {}).keys())
+    return f"{room['name']}\n{room['description']}\nExits: {exits}"
+
+@app.get("/", response_class=FileResponse)
+def index() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+@app.get("/api/start")
+def start():
+    session_id = str(uuid.uuid4())
+    sessions[session_id] = {"current_room": "entrance", "inventory": []}
+    return {"session_id": session_id, "text": describe_room("entrance")}
+
+@app.post("/api/command")
+async def command(payload: dict):
+    session_id = payload.get("session_id")
+    cmd = payload.get("command", "").strip().lower()
+    state = sessions.get(session_id)
+    if not state:
+        return {"text": "Invalid session."}
+
+    current = state["current_room"]
+    text = ""
+
+    if cmd in {"look", "l"}:
+        text = describe_room(current)
+    elif cmd.startswith("go "):
+        direction = cmd.split(maxsplit=1)[1]
+        destination = rooms[current]["exits"].get(direction)
+        if destination:
+            state["current_room"] = destination
+            text = describe_room(destination)
+        else:
+            text = "You can't go that way."
+    elif cmd in {"inventory", "i"}:
+        inv = state["inventory"]
+        text = "You are carrying: " + (", ".join(inv) if inv else "nothing.")
+    elif cmd == "help":
+        text = "Commands: look, go <direction>, inventory, map, examine <item>"
+    elif cmd == "map":
+        text = "Rooms: " + ", ".join(room["name"] for room in rooms.values())
+    elif cmd.startswith("examine "):
+        item = cmd.split(maxsplit=1)[1]
+        text = f"You see nothing special about the {item}."
+    else:
+        text = "Unknown command."
+
+    return {"text": text}
+

--- a/app/rooms.json
+++ b/app/rooms.json
@@ -1,0 +1,37 @@
+{
+  "entrance": {
+    "name": "Entrance Hall",
+    "description": "You stand in a dimly lit foyer. Exits lead north to About, east to Skills, west to Experience, south to Contact.",
+    "exits": {"north": "about", "east": "skills", "west": "experience", "south": "contact"}
+  },
+  "about": {
+    "name": "About",
+    "description": "I am an enthusiastic developer passionate about building interactive experiences.",
+    "exits": {"south": "entrance", "east": "education"}
+  },
+  "skills": {
+    "name": "Skills",
+    "description": "Proficient with Python, JavaScript, and crafting web adventures.",
+    "exits": {"west": "entrance", "south": "certifications"}
+  },
+  "education": {
+    "name": "Education",
+    "description": "B.S. in Computer Science from Example University.",
+    "exits": {"west": "about"}
+  },
+  "experience": {
+    "name": "Experience",
+    "description": "Previously built numerous applications and guided teams through quests.",
+    "exits": {"east": "entrance"}
+  },
+  "contact": {
+    "name": "Contact",
+    "description": "You can reach me at hero@example.com.",
+    "exits": {"north": "entrance"}
+  },
+  "certifications": {
+    "name": "Certifications",
+    "description": "Certified Python Professional, Cloud Adventurer.",
+    "exits": {"north": "skills"}
+  }
+}

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Resume MUD</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <div id="terminal"></div>
+  <form id="command-form">
+    <span>$</span>
+    <input id="command" autocomplete="off" autofocus />
+  </form>
+  <div id="hotkeys">
+    <button data-cmd="look" type="button">Look</button>
+    <button data-cmd="inventory" type="button">Inventory</button>
+    <button data-cmd="help" type="button">Help</button>
+    <button data-cmd="map" type="button">Map</button>
+  </div>
+  <script src="/static/script.js"></script>
+</body>
+</html>

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,0 +1,42 @@
+let sessionId;
+const terminal = document.getElementById('terminal');
+const form = document.getElementById('command-form');
+const input = document.getElementById('command');
+
+function print(text) {
+  terminal.textContent += text + '\n';
+  terminal.scrollTop = terminal.scrollHeight;
+}
+
+async function start() {
+  const res = await fetch('/api/start');
+  const data = await res.json();
+  sessionId = data.session_id;
+  print(data.text);
+}
+
+async function sendCommand(cmd) {
+  const res = await fetch('/api/command', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ session_id: sessionId, command: cmd })
+  });
+  const data = await res.json();
+  print('> ' + cmd);
+  print(data.text);
+}
+
+form.addEventListener('submit', e => {
+  e.preventDefault();
+  const cmd = input.value;
+  input.value = '';
+  sendCommand(cmd);
+});
+
+document.getElementById('hotkeys').addEventListener('click', e => {
+  if (e.target.dataset.cmd) {
+    sendCommand(e.target.dataset.cmd);
+  }
+});
+
+start();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,31 @@
+body {
+  background: #000;
+  color: #0f0;
+  font-family: monospace;
+  margin: 0;
+}
+#terminal {
+  padding: 10px;
+  height: 80vh;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+form {
+  display: flex;
+  padding: 10px;
+}
+#command {
+  flex: 1;
+  background: #000;
+  color: #0f0;
+  border: none;
+  outline: none;
+  font-family: monospace;
+}
+button {
+  margin-right: 5px;
+  background: #111;
+  color: #0f0;
+  border: 1px solid #0f0;
+  font-family: monospace;
+}


### PR DESCRIPTION
## Summary
- implement FastAPI backend that serves a MUD-style resume with basic commands and room navigation
- store resume content in JSON and expose endpoints for interactive sessions
- create terminal-like frontend with minimal HTML/CSS/JS for commands and hotkeys

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c550476d308322b45407427636a3c0