### PR TITLE
Center game and add resume layout

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -6,17 +6,43 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <div id="terminal"></div>
-  <form id="command-form">
-    <span>$</span>
-    <input id="command" autocomplete="off" autofocus />
-  </form>
-  <div id="hotkeys">
-    <button data-cmd="look" type="button">Look</button>
-    <button data-cmd="inventory" type="button">Inventory</button>
-    <button data-cmd="help" type="button">Help</button>
-    <button data-cmd="map" type="button">Map</button>
-  </div>
+  <header>
+    <h1>Jane Doe</h1>
+    <p>Software Developer</p>
+  </header>
+  <main>
+    <section id="interactive">
+      <h2>Interactive Resume</h2>
+      <div id="game-container">
+        <div id="terminal"></div>
+        <form id="command-form">
+          <span>$</span>
+          <input id="command" autocomplete="off" autofocus />
+        </form>
+        <div id="hotkeys">
+          <button data-cmd="look" type="button">Look</button>
+          <button data-cmd="inventory" type="button">Inventory</button>
+          <button data-cmd="help" type="button">Help</button>
+          <button data-cmd="map" type="button">Map</button>
+        </div>
+      </div>
+    </section>
+    <section id="about">
+      <h2>About</h2>
+      <p>Brief introduction and career objective go here.</p>
+    </section>
+    <section id="experience">
+      <h2>Experience</h2>
+      <ul>
+        <li><strong>Job Title</strong> - Company Name</li>
+        <li><strong>Job Title</strong> - Company Name</li>
+      </ul>
+    </section>
+    <section id="contact">
+      <h2>Contact</h2>
+      <p>Email: jane.doe@example.com</p>
+    </section>
+  </main>
   <script src="/static/script.js"></script>
 </body>
 </html>

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,19 +1,50 @@
 body {
+  font-family: Arial, sans-serif;
+  background: #f4f4f4;
+  color: #333;
+  margin: 0;
+  line-height: 1.6;
+}
+
+header {
+  background: #333;
+  color: #fff;
+  text-align: center;
+  padding: 1rem;
+}
+
+main {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+#game-container {
   background: #000;
   color: #0f0;
-  font-family: monospace;
-  margin: 0;
+  padding: 10px;
+  border-radius: 4px;
+  max-width: 600px;
+  margin: 2rem auto;
 }
+
 #terminal {
   padding: 10px;
-  height: 80vh;
+  height: 60vh;
   overflow-y: auto;
   white-space: pre-wrap;
+  background: #000;
 }
-form {
+
+#command-form {
   display: flex;
-  padding: 10px;
+  padding: 10px 0;
 }
+
 #command {
   flex: 1;
   background: #000;
@@ -22,6 +53,7 @@ form {
   outline: none;
   font-family: monospace;
 }
+
 button {
   margin-right: 5px;
   background: #111;
@@ -29,3 +61,4 @@ button {
   border: 1px solid #0f0;
   font-family: monospace;
 }
+


### PR DESCRIPTION
## Summary
- Wrap terminal game in a new container and place it within a full resume-style layout featuring header and content sections.
- Add modern stylesheet to center the game and style resume content with a clean design.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c57d94490c8322850c0fc310c85dcc