### PR TITLE
feat: add bidirectional navigation and projects room

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,29 @@ ROOMS_PATH = Path(__file__).parent / "rooms.json"
 with ROOMS_PATH.open() as f:
     rooms = json.load(f)
 
+# Ensure exits are bidirectional so players can return the way they came. This
+# also makes it easier to add new rooms in the future without manually
+# specifying reverse links for every connection.
+OPPOSITES = {
+    "north": "south",
+    "south": "north",
+    "east": "west",
+    "west": "east",
+    "up": "down",
+    "down": "up",
+}
+
+for room_key, room in rooms.items():
+    for direction, target_key in list(room.get("exits", {}).items()):
+        opposite = OPPOSITES.get(direction)
+        if not opposite:
+            continue
+        target_room = rooms.get(target_key)
+        if not target_room:
+            continue
+        target_exits = target_room.setdefault("exits", {})
+        target_exits.setdefault(opposite, room_key)
+
 # Serve static files
 STATIC_DIR = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
@@ -65,6 +88,19 @@ async def command(payload: dict):
         text = describe_room(current)
     elif cmd.startswith("go "):
         direction = cmd.split(maxsplit=1)[1]
+        destination = rooms[current]["exits"].get(direction)
+        if destination:
+            state["current_room"] = destination
+            text = describe_room(destination)
+        else:
+            text = "You can't go that way."
+    elif cmd in rooms[current]["exits"]:
+        destination = rooms[current]["exits"][cmd]
+        state["current_room"] = destination
+        text = describe_room(destination)
+    elif cmd in {"n", "s", "e", "w", "u", "d"}:
+        dir_lookup = {"n": "north", "s": "south", "e": "east", "w": "west", "u": "up", "d": "down"}
+        direction = dir_lookup[cmd]
         destination = rooms[current]["exits"].get(direction)
         if destination:
             state["current_room"] = destination

--- a/app/rooms.json
+++ b/app/rooms.json
@@ -21,8 +21,8 @@
   },
   "experience": {
     "name": "Experience",
-    "description": "Previously built numerous applications and guided teams through quests.",
-    "exits": {"east": "entrance"}
+    "description": "Previously built numerous applications and guided teams through quests. A passage leads north to Projects.",
+    "exits": {"east": "entrance", "north": "projects"}
   },
   "contact": {
     "name": "Contact",
@@ -33,5 +33,10 @@
     "name": "Certifications",
     "description": "Certified Python Professional, Cloud Adventurer.",
     "exits": {"north": "skills"}
+  },
+  "projects": {
+    "name": "Projects",
+    "description": "A showroom highlighting recent quests and accomplishments.",
+    "exits": {"south": "experience"}
   }
 }


### PR DESCRIPTION
## Summary
- ensure room exits are bidirectional and support future expansion
- allow moving with direction names or short commands
- add a Projects room linked from Experience

## Testing
- `python -m py_compile app/main.py`
- `pip install fastapi` (fails: Could not find a version that satisfies the requirement fastapi; Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c5825a96e483229c088d35f9b5e079