### PR TITLE
Improve resume CLI navigation

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -17,19 +17,21 @@
   </header>
   <main class="centered">
     <div id="game-container">
+      <p class="instructions">Explore this interactive resume using the command line below. Try the buttons for quick access or type <kbd>help</kbd> to see all commands.</p>
       <div id="terminal"></div>
       <form id="command-form">
         <span>$</span>
         <input id="command" autocomplete="off" autofocus />
       </form>
       <div id="hotkeys">
-        <button data-cmd="ls" type="button">ls</button>
-        <button data-cmd="pwd" type="button">pwd</button>
-        <button data-cmd="cd .." type="button">cd ..</button>
-        <button data-cmd="help" type="button">help</button>
+        <button data-cmd="open overview" type="button">Overview</button>
+        <button data-cmd="open experience" type="button">Experience</button>
+        <button data-cmd="open projects" type="button">Projects</button>
+        <button data-cmd="open education" type="button">Education</button>
+        <button data-cmd="help" type="button">Help</button>
       </div>
     </div>
-    </main>
+  </main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,8 +1,9 @@
-let sessionId;
+let sessionId; // current CLI session identifier returned by the backend
 const terminal = document.getElementById('terminal');
 const form = document.getElementById('command-form');
 const input = document.getElementById('command');
 
+// Append ``text`` to the terminal output area
 function print(text) {
   if (text) {
     terminal.textContent += text + '\n';
@@ -10,6 +11,7 @@ function print(text) {
   terminal.scrollTop = terminal.scrollHeight;
 }
 
+// Start a new CLI session and show the welcome message
 async function start() {
   const res = await fetch('/api/start');
   const data = await res.json();
@@ -17,6 +19,7 @@ async function start() {
   print(data.text);
 }
 
+// Send a command string to the backend API and render the response
 async function sendCommand(cmd) {
   const res = await fetch('/api/command', {
     method: 'POST',
@@ -31,6 +34,7 @@ async function sendCommand(cmd) {
   print(data.text);
 }
 
+// Handle manual command entry
 form.addEventListener('submit', e => {
   e.preventDefault();
   const cmd = input.value;
@@ -38,6 +42,7 @@ form.addEventListener('submit', e => {
   sendCommand(cmd);
 });
 
+// Delegate clicks on the hotkey buttons to send predefined commands
 document.getElementById('hotkeys').addEventListener('click', e => {
   if (e.target.dataset.cmd) {
     sendCommand(e.target.dataset.cmd);

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -71,6 +71,17 @@ main.centered {
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
+.instructions {
+  margin: 0 0 1rem 0;
+  color: #ccc;
+  text-align: center;
+  font-family: monospace;
+}
+
+#hotkeys {
+  margin-top: 0.5rem;
+}
+
 #terminal {
   padding: 10px;
   height: 60vh;


### PR DESCRIPTION
## Summary
- Add friendly instructions and section hotkeys to the interactive resume
- Style instructions area and clean up hotkey layout
- Document browser script for readability

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5971ac42883229ddb363042198f90