### PR TITLE
Link static pages to shared resume data

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -133,6 +133,8 @@ def render_details(section: str, item: Dict[str, Any]) -> str:
         return f"{item['name']} ({item.get('level')})"
     if section == "education":
         return f"{item['degree']} at {item['institution']} ({item['year']})"
+    if section == "certifications":
+        return item.get("name", "")
     return ""
 
 
@@ -421,6 +423,11 @@ def about() -> FileResponse:
 @app.get("/resume", response_class=FileResponse)
 def resume() -> FileResponse:
     return FileResponse(STATIC_DIR / "resume.html")
+
+
+@app.get("/api/resume")
+def get_resume() -> Dict[str, Any]:
+    return RESUME
 
 
 @app.get("/api/start")

--- a/app/resume.json
+++ b/app/resume.json
@@ -154,6 +154,14 @@
     {"id": 1, "institution": "Western Governors University", "degree": "B.S. Cloud Computing", "year": "2024"},
     {"id": 2, "institution": "ACI Learning", "degree": "Tech Bootcamp, Computer User Support Specialist Program", "year": "2022"}
   ],
+  "certifications": [
+    {"id": 1, "name": "Microsoft Azure Administrator (AZ-104)"},
+    {"id": 2, "name": "AWS Certified Cloud Practitioner"},
+    {"id": 3, "name": "CompTIA A+"},
+    {"id": 4, "name": "CompTIA Network+"},
+    {"id": 5, "name": "CompTIA Security+"},
+    {"id": 6, "name": "ITIL 4"}
+  ],
   "achievements": [],
   "service": [],
   "interests": [],

--- a/app/static/about.html
+++ b/app/static/about.html
@@ -17,10 +17,14 @@
   </header>
   <main>
     <h1>About</h1>
-    <p>I'm Chad Lindemood, an IT professional specializing in cloud and systems administration, endpoint management, and network security. I enjoy translating complex technical problems into clear solutions and building resilient infrastructure for users and organizations.</p>
+    <p id="about-text"></p>
     </main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script type="module">
+      import {loadAbout} from '/static/resume-data.js';
+      loadAbout();
+    </script>
   </body>
 </html>

--- a/app/static/education.html
+++ b/app/static/education.html
@@ -17,22 +17,16 @@
   </header>
   <main>
     <h1>Education</h1>
-    <ul>
-      <li>Western Governors University &ndash; Salt Lake City, UT &mdash; Bachelor of Science, Cloud Computing (Expected Dec 2024)</li>
-      <li>ACI Learning &ndash; Centennial, CO &mdash; Tech Bootcamp, Computer User Support Specialist Program (Sep 2022)</li>
-    </ul>
+    <ul id="education-list"></ul>
     <h2>Certifications</h2>
-    <ul>
-      <li>Microsoft Azure Administrator (AZ-104)</li>
-      <li>AWS Certified Cloud Practitioner</li>
-      <li>CompTIA A+</li>
-      <li>CompTIA Network+</li>
-      <li>CompTIA Security+</li>
-      <li>ITIL 4</li>
-    </ul>
+    <ul id="certifications-list"></ul>
     </main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script type="module">
+      import {loadEducation} from '/static/resume-data.js';
+      loadEducation();
+    </script>
   </body>
 </html>

--- a/app/static/projects.html
+++ b/app/static/projects.html
@@ -17,12 +17,14 @@
   </header>
   <main>
     <h1>Projects</h1>
-    <ul>
-      <li>Developed PowerShell scripts for device tracking and Chrome bookmark backup to streamline IT operations.</li>
-    </ul>
+    <ul id="projects-list"></ul>
     </main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script type="module">
+      import {loadProjects} from '/static/resume-data.js';
+      loadProjects();
+    </script>
   </body>
 </html>

--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -1,0 +1,133 @@
+async function fetchResume() {
+  const res = await fetch('/api/resume');
+  return await res.json();
+}
+
+export async function loadAbout() {
+  const r = await fetchResume();
+  const p = document.getElementById('about-text');
+  if (p) {
+    p.textContent = r.overview.summary;
+  }
+}
+
+export async function loadProjects() {
+  const r = await fetchResume();
+  const list = document.getElementById('projects-list');
+  if (list) {
+    r.projects.forEach(p => {
+      const li = document.createElement('li');
+      li.textContent = p.outcome ? `${p.name} — ${p.outcome}` : p.name;
+      list.appendChild(li);
+    });
+  }
+}
+
+export async function loadEducation() {
+  const r = await fetchResume();
+  const list = document.getElementById('education-list');
+  if (list) {
+    r.education.forEach(e => {
+      const li = document.createElement('li');
+      li.textContent = `${e.institution} — ${e.degree} (${e.year})`;
+      list.appendChild(li);
+    });
+  }
+  const certList = document.getElementById('certifications-list');
+  if (certList && r.certifications) {
+    r.certifications.forEach(c => {
+      const li = document.createElement('li');
+      li.textContent = c.name || c;
+      certList.appendChild(li);
+    });
+  }
+}
+
+export async function loadResume() {
+  const r = await fetchResume();
+  const main = document.getElementById('resume-container');
+  if (!main) return;
+
+  const h1 = document.createElement('h1');
+  h1.textContent = r.overview.name;
+  main.appendChild(h1);
+
+  const contact = document.createElement('p');
+  contact.innerHTML = `${r.overview.location} | ${r.overview.phone} | <a href="mailto:${r.overview.email}">${r.overview.email}</a>`;
+  main.appendChild(contact);
+
+  const expH2 = document.createElement('h2');
+  expH2.textContent = 'Professional Experience';
+  main.appendChild(expH2);
+  r.experience.forEach(exp => {
+    const h3 = document.createElement('h3');
+    h3.textContent = `${exp.role} – ${exp.company}`;
+    main.appendChild(h3);
+    const p = document.createElement('p');
+    p.textContent = `${exp.start} – ${exp.end || 'Present'} | ${exp.location}`;
+    main.appendChild(p);
+    if (exp.bullets && exp.bullets.length) {
+      const ul = document.createElement('ul');
+      exp.bullets.forEach(b => {
+        const li = document.createElement('li');
+        li.textContent = b;
+        ul.appendChild(li);
+      });
+      main.appendChild(ul);
+    }
+  });
+
+  const eduH2 = document.createElement('h2');
+  eduH2.textContent = 'Education';
+  main.appendChild(eduH2);
+  const eduUl = document.createElement('ul');
+  r.education.forEach(e => {
+    const li = document.createElement('li');
+    li.textContent = `${e.institution} – ${e.degree} (${e.year})`;
+    eduUl.appendChild(li);
+  });
+  main.appendChild(eduUl);
+
+  if (r.certifications && r.certifications.length) {
+    const certH2 = document.createElement('h2');
+    certH2.textContent = 'Certifications';
+    main.appendChild(certH2);
+    const certUl = document.createElement('ul');
+    r.certifications.forEach(c => {
+      const li = document.createElement('li');
+      li.textContent = c.name || c;
+      certUl.appendChild(li);
+    });
+    main.appendChild(certUl);
+  }
+
+  const skillH2 = document.createElement('h2');
+  skillH2.textContent = 'Technical Skills';
+  main.appendChild(skillH2);
+  const skillUl = document.createElement('ul');
+  const categories = { cloud: [], endpoint: [], network: [], collaboration: [] };
+  r.skills.forEach(s => {
+    if (Array.isArray(s.tags)) {
+      s.tags.forEach(tag => {
+        if (categories[tag]) {
+          categories[tag].push(s.name);
+        }
+      });
+    }
+  });
+  const labels = {
+    cloud: 'Cloud & Systems',
+    endpoint: 'Endpoint Management',
+    network: 'Networking & Security',
+    collaboration: 'Collaboration Tools'
+  };
+  Object.entries(labels).forEach(([tag, label]) => {
+    const names = categories[tag];
+    if (names.length) {
+      const li = document.createElement('li');
+      li.textContent = `${label}: ${names.join(', ')}`;
+      skillUl.appendChild(li);
+    }
+  });
+  main.appendChild(skillUl);
+}

--- a/app/static/resume.html
+++ b/app/static/resume.html
@@ -15,99 +15,13 @@
       <a href="/about">About</a>
     </nav>
   </header>
-  <main>
-    <h1>Chad Lindemood</h1>
-    <p>Canal Fulton, OH | (765) 470-3525 | <a href="mailto:chad.lindemood@gmail.com">chad.lindemood@gmail.com</a></p>
-
-    <h2>Professional Experience</h2>
-    <h3>Tier 2 Escalations Technician &ndash; Computer Technology Managed Services</h3>
-    <p>Dec 2024 &ndash; Present | Akron, OH</p>
-    <ul>
-      <li>Resolved advanced escalations from Tier 1 helpdesk across multiple clients, handling complex networking, system, and endpoint issues.</li>
-      <li>Directed client onboarding projects end-to-end, from requirements gathering through deployment, ensuring seamless transitions.</li>
-      <li>Completed infrastructure upgrades and troubleshooting during multi-day onsite engagements under strict deadlines.</li>
-      <li>Configured, secured, and troubleshot SonicWall and Sophos firewalls to enhance client security posture.</li>
-      <li>Administered VMware ESXi environments, remediating host and VM-level failures to maintain uptime.</li>
-      <li>Diagnosed Windows Server and Active Directory issues including GPOs, authentication, and domain outages.</li>
-      <li>Reduced repeat tickets by documenting solutions, training Tier 1 staff, and standardizing recurring fixes.</li>
-    </ul>
-
-    <h3>Field Technician &ndash; Computer Technology Managed Services</h3>
-    <p>Sep 2024 &ndash; Dec 2024 | Akron, OH</p>
-    <ul>
-      <li>Delivered onsite support for desktops and laptops, replacing RAM, drives, and displays to minimize downtime.</li>
-      <li>Maintained network infrastructure by replacing switches, UniFi Cloud Keys, and UPS batteries, while reorganizing network closets for reliability.</li>
-      <li>Supported migration and onboarding projects by imaging and deploying devices for end users.</li>
-      <li>Participated in ransomware incident response, reimaging endpoints and restoring organizational productivity.</li>
-      <li>Documented troubleshooting steps and contributed to internal knowledge base for consistent team practices.</li>
-    </ul>
-
-    <h3>EXOS IT &ndash; Noblesville, IN</h3>
-    <h4>IT Service Desk Technician II | Mar 2024 &ndash; Sep 2024</h4>
-    <ul>
-      <li>Served as primary escalation point for Tier 1 staff, managing complex technical issues and mentoring new technicians.</li>
-      <li>Authored process documentation and delivered training to improve first-call resolution.</li>
-      <li>Supported server patching and monthly updates alongside the systems administrator.</li>
-      <li>Monitored and verified Veeam backups, ensuring reliability of disaster recovery.</li>
-      <li>Collaborated on Active Directory cleanup projects, removing obsolete accounts and standardizing user provisioning.</li>
-      <li>Integrated applications with Azure AD to enable Single Sign-On, reducing password management burden.</li>
-    </ul>
-    <h4>IT Service Desk Technician I | Nov 2022 &ndash; Mar 2024</h4>
-    <ul>
-      <li>Implemented Intune and Autopilot for hybrid device provisioning, creating applications and configuration profiles.</li>
-      <li>Coordinated annual PC refresh project, managing device setup, tracking progress, and recommending hardware specs.</li>
-      <li>Streamlined operations by developing PowerShell scripts for device tracking, Chrome bookmark backup, and automation tasks.</li>
-      <li>Delivered Microsoft Office Suite training and daily support for end users.</li>
-      <li>Configured Microsoft Teams Rooms with both hardware and software deployments.</li>
-      <li>Assisted networking team with VPN, switch rewiring, access points, and cabling tasks.</li>
-    </ul>
-
-    <h3>Stay-at-Home Father</h3>
-    <p>Jan 2015 &ndash; Jul 2022 | Miami, FL</p>
-    <ul>
-      <li>Applied time management, multitasking, and organizational discipline to balance competing demands.</li>
-    </ul>
-
-    <h3>Hall of Fame Flooring &ndash; Cleveland, OH</h3>
-    <h4>Flooring Installer | Jun 2012 &ndash; Dec 2014</h4>
-    <ul>
-      <li>Communicated directly with customers to ensure accurate requirements and high-quality service delivery.</li>
-    </ul>
-
-    <h3>United States Air Force &ndash; Fort Meade, MD</h3>
-    <h4>Signals Intelligence Analyst | Mar 2008 &ndash; Mar 2012</h4>
-    <ul>
-      <li>Conducted complex signal analysis with advanced technical tools.</li>
-      <li>Collaborated with teams to share intelligence and improve communication channels.</li>
-      <li>Developed expertise in data analysis and technical problem solving.</li>
-    </ul>
-
-    <h2>Education</h2>
-    <ul>
-      <li>Western Governors University &ndash; Salt Lake City, UT &mdash; Bachelor of Science, Cloud Computing (Expected Dec 2024)</li>
-      <li>ACI Learning &ndash; Centennial, CO &mdash; Tech Bootcamp, Computer User Support Specialist Program (Sep 2022)</li>
-    </ul>
-
-    <h2>Certifications</h2>
-    <ul>
-      <li>Microsoft Azure Administrator (AZ-104)</li>
-      <li>AWS Certified Cloud Practitioner</li>
-      <li>CompTIA A+</li>
-      <li>CompTIA Network+</li>
-      <li>CompTIA Security+</li>
-      <li>ITIL 4</li>
-    </ul>
-
-    <h2>Technical Skills</h2>
-    <ul>
-      <li>Cloud &amp; Systems: Azure, Active Directory, Windows Server, VMware ESXi</li>
-      <li>Endpoint Management: Microsoft Intune, Autopilot, PowerShell scripting</li>
-      <li>Networking &amp; Security: SonicWall, Sophos, VPN, UniFi, Veeam backups</li>
-      <li>Collaboration Tools: Microsoft Teams Rooms, Office Suite</li>
-    </ul>
-    </main>
+  <main id="resume-container"></main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script type="module">
+      import {loadResume} from '/static/resume-data.js';
+      loadResume();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Expose resume data through a new `/api/resume` endpoint.
- Add a shared `resume-data.js` module to populate About, Projects, Education, and Resume pages from the same JSON used by the CLI.
- Extend resume JSON with certifications and support them in the CLI renderer.

## Testing
- `python -m py_compile app/main.py`
- `pip install fastapi` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c59d1b95d08322af892a59c3aa0f0d