### PR TITLE
Polish CLI display and help content

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,7 +58,8 @@ def format_date(value: str | None) -> str:
     if not value:
         return "Present"
     try:
-        return datetime.strptime(value, "%Y-%m").strftime("%b %Y")
+        dt = datetime.strptime(value, "%Y-%m")
+        return f"{dt.month} {dt.year}"
     except ValueError:
         return value
 
@@ -120,7 +121,10 @@ def list_section(state: Dict[str, Any], section: str, *, expand: bool = False, p
         lines.append(base)
         if expand:
             lines.append(render_details(section, item))
-    lines.append(f"Page {page}/{total_pages} • use 'show <id>' or 'expand <id>'")
+    hint = " • type 'next' to see more" if page < total_pages else ""
+    lines.append(
+        f"Page {page}/{total_pages} • use 'show <id>' or 'expand <id>'{hint}"
+    )
     return "\n".join(lines)
 
 
@@ -435,7 +439,7 @@ HELP_TEXT = (
     "  back                                 — return to previous view\n"
     "  search <query> [--in <section>]      — full-text search\n"
     "  filter [section] field=value         — filter items\n"
-    "  timeline                             — show experience timeline\n"
+    "  timeline [--section <name>]          — show section timeline\n"
     "  certifications [--expand] [--page N] — list certifications\n"
     "  skills [--level L] [--tag t1,t2]     — list skills\n"
     "  contact                              — show contact info\n"
@@ -445,19 +449,27 @@ HELP_TEXT = (
     "  versions [--list|--diff]             — resume versions\n"
     "  tags --list|--add|--remove           — manage tags\n"
     "  notes --add|--show                   — manage notes\n"
-    "  print [--detailed]                   — print resume\n"
-    "  theme <name>                         — set theme\n"
-    "  about                                — show resume metadata\n"
-    "  clear                                — clear screen\n"
-    "  quit                                 — exit the game\n"
     "Type 'help <command>' for more details."
 )
 
 COMMAND_HELP = {
     "open": "open <section> [--expand] [--page N] — show a section.",
     "show": "show <id> — open one item by its ID from the last listing. You can also type the id number directly.",
+    "next": "next — go to the next page of the current section.",
+    "prev": "prev — go to the previous page of the current section.",
+    "back": "back — return to the previous view.",
     "search": "search <query> [--in <section>] — full-text search.",
+    "filter": "filter [section] field=value — filter items.",
+    "timeline": "timeline [--section <name>] — show a section timeline.",
     "certifications": "certifications [--expand] [--page N] — list certifications.",
+    "skills": "skills [--level L] [--tag t1,t2] — list skills.",
+    "contact": "contact — show contact info.",
+    "copy": "copy <field> — copy a field from the overview section.",
+    "share": "share — show the public resume link.",
+    "download": "download [--filename name] — download the resume.",
+    "versions": "versions [--list|--diff] — resume versions or diff.",
+    "tags": "tags --list|--add <id> <tag>|--remove <id> <tag> — manage tags.",
+    "notes": "notes --add <id> 'text'|--show <id> — manage notes.",
 }
 
 # ---------------------------------------------------------------------------

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -28,6 +28,7 @@
         <button data-cmd="open experience" type="button">Experience</button>
         <button data-cmd="open projects" type="button">Projects</button>
         <button data-cmd="open education" type="button">Education</button>
+        <!-- Certifications shortcut -->
         <button data-cmd="open certifications" type="button">Certifications</button>
         <button data-cmd="help" type="button">Help</button>
       </div>

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -14,8 +14,8 @@ function escapeHtml(text) {
 // Add simple syntax highlighting to imitate IDE colour schemes
 function colorize(text) {
   return escapeHtml(text)
-    .replace(/https?:\/\/[^\s]+/g, '<a href="$&" class="link" target="_blank">$&</a>')
-    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '<a href="mailto:$&" class="link" target="_blank">$&</a>')
+    .replace(/https?:\/\/[^\s]+/g, '<span class="link">$&</span>')
+    .replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, '<span class="link">$&</span>')
     .replace(/\[(.*?)\]/g, '<span class="bracket">[$1]</span>')
     .replace(/\b([A-Za-z_]+):/g, '<span class="label">$1:</span>')
     .replace(/\b\d+\b/g, '<span class="number">$&</span>')


### PR DESCRIPTION
## Summary
- Avoid converting URLs and emails into clickable links to preserve terminal theme colours.
- Show numeric month numbers in experience entries and hint users to type `next` for more pages.
- Streamline help text and add per-command help while ensuring certifications hotkey is exposed.

## Testing
- ⚠️ `pytest` (no tests ran)

------
https://chatgpt.com/codex/tasks/task_e_68c5bf7095a48322b6aa2c2b9bdd9ca7