### PR TITLE
Refine link styling and date formatting

### DIFF
--- a/app/filesystem.json
+++ b/app/filesystem.json
@@ -16,12 +16,12 @@
       "content": "WGU – B.S. Cloud Computing (expected Dec 2024); ACI Learning – Tech Bootcamp.",
       "type": "file"
     },
-    "experience.txt": {
-      "content": "Experience spanning Tier 2 Escalations, Field Technician, IT Service Desk roles, Stay-at-Home Father, Flooring Installer, and Signals Intelligence Analyst.",
-      "type": "file"
-    },
-    "projects": {
-      "children": {
+      "experience.txt": {
+        "content": "Experience spanning Tier 2 Escalations, Field Technician II, IT Service Desk roles, Stay-at-Home Father, Flooring Installer, and Signals Intelligence Analyst.",
+        "type": "file"
+      },
+      "projects": {
+        "children": {
         "bookmark-backup.txt": {
           "content": "Chrome bookmark backup automation.",
           "type": "file"

--- a/app/resume.json
+++ b/app/resume.json
@@ -77,7 +77,7 @@
       "end": "2024-12",
       "id": 2,
       "location": "Akron, OH",
-      "role": "Field Technician",
+      "role": "Field Technician II",
       "start": "2024-09",
       "tech": [
         "UniFi",

--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -3,11 +3,18 @@ async function fetchResume() {
   return await res.json();
 }
 
-function formatDate(str) {
+function stripScheme(url) {
+  return url.replace(/^https?:\/\//, '');
+}
+
+function formatDate(str, short = false) {
   if (!str) return 'Present';
-  const [y, m] = str.split('-');
-  const d = new Date(Number(y), Number(m) - 1);
-  return d.toLocaleString('en-US', { month: 'short', year: 'numeric' });
+  const parts = str.split('-');
+  const y = Number(parts[0]);
+  const m = Number(parts[1]);
+  const d = parts[2] ? Number(parts[2]) : 1;
+  const year = short ? String(y).slice(-2) : y;
+  return `${m}/${d}/${year}`;
 }
 
 export async function loadAbout() {
@@ -60,7 +67,7 @@ export async function loadResume() {
   main.appendChild(h1);
 
   const contact = document.createElement('p');
-  contact.innerHTML = `${r.overview.location} | ${r.overview.phone} | <a href="mailto:${r.overview.email}">${r.overview.email}</a> | <a href="${r.overview.web}" target="_blank">${r.overview.web}</a> | <a href="${r.overview.linkedin}" target="_blank">${r.overview.linkedin}</a> | <a href="${r.overview.github}" target="_blank">${r.overview.github}</a>`;
+  contact.innerHTML = `${r.overview.location} | ${r.overview.phone} | <a href="mailto:${r.overview.email}">${r.overview.email}</a> | <a href="${r.overview.web}" target="_blank">${stripScheme(r.overview.web)}</a> | <a href="${r.overview.linkedin}" target="_blank">${stripScheme(r.overview.linkedin)}</a> | <a href="${r.overview.github}" target="_blank">${stripScheme(r.overview.github)}</a>`;
   main.appendChild(contact);
 
   const expH2 = document.createElement('h2');
@@ -71,7 +78,7 @@ export async function loadResume() {
     h3.textContent = `${exp.role} – ${exp.company}`;
     main.appendChild(h3);
     const p = document.createElement('p');
-    p.textContent = `${formatDate(exp.start)} – ${formatDate(exp.end)} | ${exp.location}`;
+    p.textContent = `${formatDate(exp.start)} - ${formatDate(exp.end, true)} | ${exp.location}`;
     main.appendChild(p);
     if (exp.bullets && exp.bullets.length) {
       const ul = document.createElement('ul');

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -54,6 +54,16 @@ main {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 
+a {
+  color: #4ca1af;
+  text-decoration: none;
+}
+
+a:hover {
+  color: #2c3e50;
+  text-decoration: underline;
+}
+
 main.centered {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Summary
- style links with a new color scheme and drop visible `https://` prefixes
- show experience dates as numeric ranges with default day-of-month
- rename Field Technician position to Field Technician II across data files

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c5c3ea3ce4832284c2c7c7ae31ae3b