### PR TITLE
Refine resume links and certifications

### DIFF
--- a/app/filesystem.json
+++ b/app/filesystem.json
@@ -5,11 +5,11 @@
       "type": "file"
     },
     "certifications.txt": {
-      "content": "Azure Administrator, AWS Cloud Practitioner, CompTIA A+, Network+, Security+, ITIL 4.",
+      "content": "Cisco Certified Network Associate; Microsoft Azure Administrator (AZ-104); AWS Certified Cloud Practitioner; CompTIA A+ (220-1101 + 220-1102); CompTIA Network+ (N10-008); CompTIA Security+ (SY0-601); Microsoft SC-900; Microsoft Azure Data Fundamentals (DP-900); ITIL 4.",
       "type": "file"
     },
     "contact.txt": {
-      "content": "Reach Chad at chad.lindemood@gmail.com or (765) 470-3525 in Canal Fulton, OH.",
+      "content": "Reach Chad at chad.lindemood@gmail.com in Canal Fulton, OH.",
       "type": "file"
     },
     "education.txt": {

--- a/app/main.py
+++ b/app/main.py
@@ -72,7 +72,12 @@ def format_date(value: str | None, short: bool = False) -> str:
 
 
 def strip_scheme(url: str | None) -> str:
-    return url.replace("https://", "").replace("http://", "") if url else ""
+    if not url:
+        return ""
+    url = url.replace("https://", "").replace("http://", "")
+    if url.startswith("www."):
+        url = url[4:]
+    return url
 
 
 def format_overview() -> str:
@@ -165,7 +170,19 @@ def render_details(section: str, item: Dict[str, Any]) -> str:
     if section == "education":
         return f"{item['degree']} at {item['institution']} ({item['year']})"
     if section == "certifications":
-        return item.get("name", "")
+        parts = [item.get("name", "")]
+        details = []
+        if issuer := item.get("issuer"):
+            details.append(issuer)
+        if issued := item.get("issued"):
+            details.append(f"Issued {format_date(issued)}")
+        if expires := item.get("expires"):
+            details.append(f"Expires {format_date(expires)}")
+        if cred := item.get("credential_id"):
+            details.append(f"ID {cred}")
+        if details:
+            parts.append(" – " + " · ".join(details))
+        return "".join(parts)
     return ""
 
 

--- a/app/resume.json
+++ b/app/resume.json
@@ -3,27 +3,68 @@
   "certifications": [
     {
       "id": 1,
-      "name": "Microsoft Azure Administrator (AZ-104)"
+      "name": "Cisco Certified Network Associate",
+      "issuer": "Cisco",
+      "issued": "2025-09",
+      "expires": "2028-09",
+      "credential_id": "275797448"
     },
     {
       "id": 2,
-      "name": "AWS Certified Cloud Practitioner"
+      "name": "AZ-104: Microsoft Azure Administrator Associate",
+      "issuer": "Microsoft",
+      "issued": "2023-06"
     },
     {
       "id": 3,
-      "name": "CompTIA A+"
+      "name": "AWS Certified Cloud Practitioner",
+      "issuer": "Amazon Web Services (AWS)",
+      "issued": "2023-05",
+      "expires": "2026-05"
     },
     {
       "id": 4,
-      "name": "CompTIA Network+"
+      "name": "CompTIA Network+ N10-008",
+      "issuer": "CompTIA",
+      "issued": "2022-12",
+      "expires": "2025-12",
+      "credential_id": "438017330"
     },
     {
       "id": 5,
-      "name": "CompTIA Security+"
+      "name": "CompTIA Security+ SY0-601",
+      "issuer": "CompTIA",
+      "issued": "2022-11",
+      "expires": "2025-11",
+      "credential_id": "435440541"
     },
     {
       "id": 6,
-      "name": "ITIL 4"
+      "name": "CompTIA A+ (220-1101 + 220-1102)",
+      "issuer": "CompTIA",
+      "issued": "2023-01",
+      "expires": "2026-01",
+      "credential_id": "439456615"
+    },
+    {
+      "id": 7,
+      "name": "SC-900: Microsoft Security, Compliance, and Identity Fundamentals",
+      "issuer": "Microsoft",
+      "issued": "2023-01",
+      "credential_id": "I588-5933"
+    },
+    {
+      "id": 8,
+      "name": "Azure Data Fundamentals (DP-900)",
+      "issuer": "Microsoft",
+      "issued": "2023-05"
+    },
+    {
+      "id": 9,
+      "name": "ITIL\u00ae Foundation 4 Certificate in IT Service Management",
+      "issuer": "PeopleCert",
+      "issued": "2022-08",
+      "credential_id": "GR671423316CL"
     }
   ],
   "education": [
@@ -172,13 +213,12 @@
   },
   "overview": {
     "email": "chad.lindemood@gmail.com",
-    "linkedin": "https://www.linkedin.com/in/chadlindemood/",
+    "linkedin": "https://linkedin.com/in/chadlindemood/",
     "location": "Canal Fulton, OH",
     "name": "Chad Lindemood",
-    "phone": "(765) 470-3525",
     "summary": "IT professional specializing in cloud and systems administration, endpoint management, and network security.",
     "title": "Tier 2 Escalations Technician",
-    "web": "[needs updated].com",
+    "web": "https://chadlindemood.com",
     "github": "https://github.com/clindemood"
   },
   "projects": [

--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -4,7 +4,7 @@ async function fetchResume() {
 }
 
 function stripScheme(url) {
-  return url.replace(/^https?:\/\//, '');
+  return url.replace(/^https?:\/\/(www\.)?/, '');
 }
 
 function formatDate(str, short = false) {
@@ -51,7 +51,12 @@ export async function loadEducation() {
   if (certList && r.certifications) {
     r.certifications.forEach(c => {
       const li = document.createElement('li');
-      li.textContent = c.name || c;
+      const details = [];
+      if (c.issuer) details.push(c.issuer);
+      if (c.issued) details.push(`Issued ${formatDate(c.issued)}`);
+      if (c.expires) details.push(`Expires ${formatDate(c.expires)}`);
+      if (c.credential_id) details.push(`ID ${c.credential_id}`);
+      li.textContent = details.length ? `${c.name} — ${details.join(' · ')}` : c.name;
       certList.appendChild(li);
     });
   }
@@ -67,7 +72,14 @@ export async function loadResume() {
   main.appendChild(h1);
 
   const contact = document.createElement('p');
-  contact.innerHTML = `${r.overview.location} | ${r.overview.phone} | <a href="mailto:${r.overview.email}">${r.overview.email}</a> | <a href="${r.overview.web}" target="_blank">${stripScheme(r.overview.web)}</a> | <a href="${r.overview.linkedin}" target="_blank">${stripScheme(r.overview.linkedin)}</a> | <a href="${r.overview.github}" target="_blank">${stripScheme(r.overview.github)}</a>`;
+  const parts = [
+    r.overview.location,
+    `<a href="mailto:${r.overview.email}">${r.overview.email}</a>`,
+    `<a href="${r.overview.web}" target="_blank">${stripScheme(r.overview.web)}</a>`,
+    `<a href="${r.overview.linkedin}" target="_blank">LinkedIn</a>`,
+    `<a href="${r.overview.github}" target="_blank">GitHub</a>`
+  ];
+  contact.innerHTML = parts.join(' | ');
   main.appendChild(contact);
 
   const expH2 = document.createElement('h2');
@@ -109,7 +121,12 @@ export async function loadResume() {
     const certUl = document.createElement('ul');
     r.certifications.forEach(c => {
       const li = document.createElement('li');
-      li.textContent = c.name || c;
+      const details = [];
+      if (c.issuer) details.push(c.issuer);
+      if (c.issued) details.push(`Issued ${formatDate(c.issued)}`);
+      if (c.expires) details.push(`Expires ${formatDate(c.expires)}`);
+      if (c.credential_id) details.push(`ID ${c.credential_id}`);
+      li.textContent = details.length ? `${c.name} — ${details.join(' · ')}` : c.name;
       certUl.appendChild(li);
     });
     main.appendChild(certUl);


### PR DESCRIPTION
## Summary
- Strip `www` alongside `http/https` for cleaner URL display
- Remove phone number and present labeled contact links on resume
- Expand certification data with issuers, dates, and credential IDs

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5c775bcb883229fca4fba9b79dc49