### PR TITLE
Refresh game humor and certification display

### DIFF
--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -53,8 +53,6 @@ export async function loadEducation() {
       const li = document.createElement('li');
       const details = [];
       if (c.issuer) details.push(c.issuer);
-      if (c.issued) details.push(`Issued ${formatDate(c.issued)}`);
-      if (c.expires) details.push(`Expires ${formatDate(c.expires)}`);
       if (c.credential_id) details.push(`ID ${c.credential_id}`);
       li.textContent = details.length ? `${c.name} — ${details.join(' · ')}` : c.name;
       certList.appendChild(li);
@@ -123,8 +121,6 @@ export async function loadResume() {
       const li = document.createElement('li');
       const details = [];
       if (c.issuer) details.push(c.issuer);
-      if (c.issued) details.push(`Issued ${formatDate(c.issued)}`);
-      if (c.expires) details.push(`Expires ${formatDate(c.expires)}`);
       if (c.credential_id) details.push(`ID ${c.credential_id}`);
       li.textContent = details.length ? `${c.name} — ${details.join(' · ')}` : c.name;
       certUl.appendChild(li);

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -53,7 +53,13 @@ async function sendCommand(cmd) {
   if (data.clear) {
     terminal.textContent = '';
   }
-  print(data.text, data.error ? 'error' : 'output');
+  if (Array.isArray(data.lines)) {
+    data.lines.forEach((line, idx) => {
+      setTimeout(() => print(line, data.error ? 'error' : 'output'), idx * 300);
+    });
+  } else {
+    print(data.text, data.error ? 'error' : 'output');
+  }
 }
 
 // Handle manual command entry


### PR DESCRIPTION
## Summary
- replace front-page CLI greeting with ASCII art and clearer instructions
- hide issued/expiration dates on certification lists while keeping detailed info in CLI
- make the secret minigame friendlier: partial look/attack names, humorous attack text, and delayed battle messages
- drop outdated reference to an `expand` command in listings

## Testing
- `pytest`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5cbf38f00832293a1fbcd6e518a35