### PR TITLE
Improve CLI game, command history and content updates

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -307,7 +307,12 @@ def handle_secret_game(state: Dict[str, Any], command: str, args: List[str]) -> 
         return {"text": stats + "\nEquipment: " + items}
     if command == "look" and not args:
         return {
-            "text": "A dusky back-room buzzing with tired tech, lit by the glow of misbehaving machines."
+            "text": (
+                "A dusky back-room buzzes with tired tech, lit only by the erratic glow of misbehaving machines. "
+                "Cables sprawl like vines across the floor, linking towers of aging gear that hum and whir in protest. "
+                "The air smells of ozone and burnt coffee, relics of late-night fixes. "
+                "Somewhere a fan sputters, challenging any brave admin to bring order to the chaos."
+            )
         }
     if command == "look" and args:
         target = args[0].lower()
@@ -748,15 +753,22 @@ def start() -> Dict[str, Any]:
     session_id = str(uuid.uuid4())
     sessions[session_id] = {}
     ascii_art = r"""
-      ____________________
-     |  ________________  |
-     | |                | |
-     | |  Tech Terminal | |
-     | |________________| |
-     |____________________|
-      \__________________/
-        |              |
-        |______________|
+                       __====-_  _-====__
+                  _--^^^#####//      \#####^^^--_
+               _-^##########// (    ) \##########^-_
+              -############//  |\^^/|  \############-
+            _/############//   (@::@)   \############\_
+           /#############((     \\//     ))#############\
+          -###############\\    (oo)    //###############-
+         -#################\\  / VV \  //#################-
+        -###################\\/      \//###################-
+       _#/|##########/\######(   /\   )######/\##########|\#_
+       |/ |#/\#/\#/\/  \#/\##\  |  |  /##/\#/  \/\#/\#/\#| \|
+       `  |/  V  V `   V  \#\| |  | |/#/  V   '  V  V  \|  '
+          `   `  `       `   / |  | \   '      '  '   '
+                            (  |  |  )
+                           __\ |  | /__
+                          (vvv(VVV)vvv)
 """
     text = (
         ascii_art

--- a/app/static/about.html
+++ b/app/static/about.html
@@ -16,15 +16,13 @@
     </nav>
   </header>
   <main>
-    <h1>About</h1>
-    <p id="about-text"></p>
-    </main>
-    <footer>
-      <p>&copy; 2024 Chad Lindemood</p>
-    </footer>
-    <script type="module">
-      import {loadAbout} from '/static/resume-data.js';
-      loadAbout();
-    </script>
+    <h1>About Me</h1>
+    <p>I’m an IT professional with a background that ranges from service in the U.S. Air Force to supporting businesses through complex technical challenges. Over the years I’ve built a career around solving problems, improving systems, and helping teams work more securely and efficiently.</p>
+    <p>Beyond work, I’m a father first. My two boys, Damien (14) and Dimitri (8), keep me motivated and grounded. When I’m not troubleshooting servers or configuring networks, you’ll find me in the gym, on a motorcycle, or in the garage working on woodworking and laser engraving projects. I’m also an avid reader of sci-fi and fantasy, always drawn to stories that spark imagination and creativity.</p>
+    <p>My professional life is about technology and reliability. My personal life is about growth, creativity, and family. Together, they shape how I approach every challenge—with focus, discipline, and curiosity.</p>
+  </main>
+  <footer>
+    <p>&copy; 2024 Chad Lindemood</p>
+  </footer>
   </body>
 </html>

--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -51,10 +51,7 @@ export async function loadEducation() {
   if (certList && r.certifications) {
     r.certifications.forEach(c => {
       const li = document.createElement('li');
-      const details = [];
-      if (c.issuer) details.push(c.issuer);
-      if (c.credential_id) details.push(`ID ${c.credential_id}`);
-      li.textContent = details.length ? `${c.name} — ${details.join(' · ')}` : c.name;
+      li.textContent = c.name;
       certList.appendChild(li);
     });
   }

--- a/app/static/script.js
+++ b/app/static/script.js
@@ -2,6 +2,8 @@ let sessionId; // current CLI session identifier returned by the backend
 const terminal = document.getElementById('terminal');
 const form = document.getElementById('command-form');
 const input = document.getElementById('command');
+const history = [];
+let historyIndex = -1;
 
 // Escape HTML special characters so user content cannot inject markup
 function escapeHtml(text) {
@@ -67,7 +69,30 @@ form.addEventListener('submit', e => {
   e.preventDefault();
   const cmd = input.value;
   input.value = '';
+  if (cmd) {
+    history.push(cmd);
+    historyIndex = history.length;
+  }
   sendCommand(cmd);
+});
+
+input.addEventListener('keydown', e => {
+  if (e.key === 'ArrowUp') {
+    if (historyIndex > 0) {
+      historyIndex--;
+      input.value = history[historyIndex];
+    }
+    e.preventDefault();
+  } else if (e.key === 'ArrowDown') {
+    if (historyIndex < history.length - 1) {
+      historyIndex++;
+      input.value = history[historyIndex];
+    } else {
+      historyIndex = history.length;
+      input.value = '';
+    }
+    e.preventDefault();
+  }
 });
 
 // Delegate clicks on the hotkey buttons to send predefined commands


### PR DESCRIPTION
## Summary
- Expand admin arena room description for richer atmosphere
- Add command history navigation to the CLI input
- Replace terminal ASCII art with an epic dragon
- Limit education page certifications to names only
- Revise About page with new personal bio

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5d27f8ee48322a335ae748671af21