### PR TITLE
Sort projects by recency and tweak landing visuals

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -776,29 +776,16 @@ def start() -> Dict[str, Any]:
             /_|_\
            //   \\
           //     \\
-          ||     ||
-          ||     ||
-          ||     ||
-          ||     ||
-         /__\   /__\
+           \\   //
+            \\ //
+             \//
+             VV
+             VV
 """
     text = (
         ascii_art
-        + "\nWelcome to the interactive resume terminal.\n\n"
-        + (
-            "This playful command-line interface lets you explore my professional "
-            "background as if you were navigating a familiar shell. Each section of "
-            "my resume can be opened, paged through, and expanded with simple text "
-            "commands.\n\n"
-            "Try browsing through experience, projects, or education, or jump "
-            "straight to the certifications that validate my skills. Search for "
-            "keywords, reveal details, and discover hidden extras designed to make "
-            "the exploration both informative and fun.\n\n"
-            "Whether you're clicking the shortcut buttons or typing directly into "
-            "the prompt, the goal is to provide a fast and accessible way to get to "
-            "know my work."
-        )
-        + "\n\nType 'help' to explore commands or 'open overview' to begin.\n"
+        + "\nWelcome to the interactive resume terminal.\n"
+        + "Type 'help' for commands or 'open overview' to begin.\n"
         + f"Last updated: {RESUME['meta']['last_updated']}"
     )
     return {"session_id": session_id, "text": text}

--- a/app/resume.json
+++ b/app/resume.json
@@ -223,53 +223,17 @@
   },
   "projects": [
     {
-      "id": 1,
-      "name": "Basic Secure Network Lab",
-      "start": "2022-11",
+      "id": 6,
+      "name": "Advanced Cisco Enterprise Network Lab",
+      "start": "2025-09",
       "role": "Author",
       "bullets": [
-        "Built a small Packet Tracer lab with 2 routers, 2 switches, and multiple VLANs.",
-        "Configured static routing, DHCP, NAT, and ACLs to restrict traffic between VLANs.",
-        "Documented a basic network topology and simulated external internet access."
+        "Built an advanced EVE-NG topology simulating a branch office network.",
+        "Configured dynamic routing with OSPF, inter-VLAN routing, and port security.",
+        "Implemented SNMP monitoring and Syslog forwarding.",
+        "Validated resiliency by simulating link failures and verifying failover."
       ],
-      "tech": ["Packet Tracer", "DHCP", "NAT", "ACLs"]
-    },
-    {
-      "id": 2,
-      "name": "Active Directory & Endpoint Management Lab",
-      "start": "2023-01",
-      "role": "Author",
-      "bullets": [
-        "Set up a Windows Server VM running Active Directory Domain Services.",
-        "Joined Windows 10 clients to the domain, created user accounts, and tested Group Policies.",
-        "Integrated an Azure AD trial tenant for hybrid identity experiments."
-      ],
-      "tech": ["Windows Server", "Active Directory", "Azure AD"]
-    },
-    {
-      "id": 3,
-      "name": "Cloud Foundations Deployment",
-      "start": "2023-05",
-      "role": "Author",
-      "bullets": [
-        "Deployed a small website to both AWS EC2 and Azure App Services.",
-        "Configured IAM and RBAC roles for secure access management.",
-        "Used S3 and Azure Storage to host static content and compared performance."
-      ],
-      "tech": ["AWS", "Azure", "IAM", "RBAC"]
-    },
-    {
-      "id": 4,
-      "name": "Firewall and Intrusion Detection Lab",
-      "start": "2023-06",
-      "role": "Author",
-      "bullets": [
-        "Deployed a pfSense firewall and connected it to both Windows and Linux VMs.",
-        "Configured stateful firewall rules, VLAN segmentation, and port forwarding.",
-        "Integrated Suricata IDS to monitor for malicious traffic patterns.",
-        "Tested security by running controlled nmap scans and logging alerts."
-      ],
-      "tech": ["pfSense", "Suricata", "nmap"]
+      "tech": ["EVE-NG", "OSPF", "SNMP"]
     },
     {
       "id": 5,
@@ -285,17 +249,53 @@
       "tech": ["EVE-NG", "Cisco IOSv", "Ansible", "Grafana"]
     },
     {
-      "id": 6,
-      "name": "Advanced Cisco Enterprise Network Lab",
-      "start": "2025-09",
+      "id": 4,
+      "name": "Firewall and Intrusion Detection Lab",
+      "start": "2023-06",
       "role": "Author",
       "bullets": [
-        "Built an advanced EVE-NG topology simulating a branch office network.",
-        "Configured dynamic routing with OSPF, inter-VLAN routing, and port security.",
-        "Implemented SNMP monitoring and Syslog forwarding.",
-        "Validated resiliency by simulating link failures and verifying failover."
+        "Deployed a pfSense firewall and connected it to both Windows and Linux VMs.",
+        "Configured stateful firewall rules, VLAN segmentation, and port forwarding.",
+        "Integrated Suricata IDS to monitor for malicious traffic patterns.",
+        "Tested security by running controlled nmap scans and logging alerts."
       ],
-      "tech": ["EVE-NG", "OSPF", "SNMP"]
+      "tech": ["pfSense", "Suricata", "nmap"]
+    },
+    {
+      "id": 3,
+      "name": "Cloud Foundations Deployment",
+      "start": "2023-05",
+      "role": "Author",
+      "bullets": [
+        "Deployed a small website to both AWS EC2 and Azure App Services.",
+        "Configured IAM and RBAC roles for secure access management.",
+        "Used S3 and Azure Storage to host static content and compared performance."
+      ],
+      "tech": ["AWS", "Azure", "IAM", "RBAC"]
+    },
+    {
+      "id": 2,
+      "name": "Active Directory & Endpoint Management Lab",
+      "start": "2023-01",
+      "role": "Author",
+      "bullets": [
+        "Set up a Windows Server VM running Active Directory Domain Services.",
+        "Joined Windows 10 clients to the domain, created user accounts, and tested Group Policies.",
+        "Integrated an Azure AD trial tenant for hybrid identity experiments."
+      ],
+      "tech": ["Windows Server", "Active Directory", "Azure AD"]
+    },
+    {
+      "id": 1,
+      "name": "Basic Secure Network Lab",
+      "start": "2022-11",
+      "role": "Author",
+      "bullets": [
+        "Built a small Packet Tracer lab with 2 routers, 2 switches, and multiple VLANs.",
+        "Configured static routing, DHCP, NAT, and ACLs to restrict traffic between VLANs.",
+        "Documented a basic network topology and simulated external internet access."
+      ],
+      "tech": ["Packet Tracer", "DHCP", "NAT", "ACLs"]
     }
   ],
   "service": [],

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -17,7 +17,7 @@
   </header>
   <main class="centered">
     <div id="game-container">
-      <p class="instructions">Explore this interactive resume using the command line below. Try the buttons for quick access or type <kbd>help</kbd> to see all commands. You can navigate sections with <kbd>open &lt;section&gt;</kbd> or even try <kbd>open secret</kbd> for a hidden mini‑game.</p>
+      <h2 class="instructions">Interactive Resume</h2>
       <div id="terminal"></div>
       <form id="command-form">
         <span>$</span>


### PR DESCRIPTION
## Summary
- reorder projects dataset to list newest work first
- streamline home page with flame-powered rocket and shorter greeting
- replace long introductory paragraph with simple heading

## Testing
- `python -m py_compile app/main.py && python -m json.tool app/resume.json >/tmp/resume.json`


------
https://chatgpt.com/codex/tasks/task_e_68c5da842f30832286fbc613cb9aadd5