### PR TITLE
Clarify CLI navigation and add layout enhancements

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -142,7 +142,7 @@ def list_section(state: Dict[str, Any], section: str, *, expand: bool = False, p
             lines.append(render_details(section, item))
     hint = " • type 'next' to see more" if page < total_pages else ""
     lines.append(
-        f"Page {page}/{total_pages} • use 'show <id>'{hint}"
+        f"Page {page}/{total_pages} • use 'show <id>' or type the number{hint}"
     )
     return "\n".join(lines)
 
@@ -443,6 +443,10 @@ def handle_command(state: Dict[str, Any], cmd: str) -> Dict[str, Any]:
             return {
                 "text": (
                     "You slip into a hidden admin arena, a dusky back-room buzzing with tired tech. "
+                    "Dust-caked racks loom in the shadows, cables snake like vines across scuffed concrete, "
+                    "and the air thrums with the low hum of overworked servers. "
+                    "Flickering LEDs cast restless patterns across abandoned manuals and half-empty coffee cups, "
+                    "painting the space as both sanctuary and battleground for weary sysadmins. "
                     "Targets: printer, server, MDF. "
                     "Use 'attack <target>' (or 'atk'), 'equipment' ('eq'), "
                     "'look <thing>' ('l') or 'exit' ('q') to leave."

--- a/app/static/about.html
+++ b/app/static/about.html
@@ -17,6 +17,7 @@
   </header>
   <main>
     <h1>About Me</h1>
+      <div class="photo-placeholder"></div>
     <p>I’m an IT professional with a background that ranges from service in the U.S. Air Force to supporting businesses through complex technical challenges. Over the years I’ve built a career around solving problems, improving systems, and helping teams work more securely and efficiently.</p>
     <p>Beyond work, I’m a father first. My two boys, Damien (14) and Dimitri (8), keep me motivated and grounded. When I’m not troubleshooting servers or configuring networks, you’ll find me in the gym, on a motorcycle, or in the garage working on woodworking and laser engraving projects. I’m also an avid reader of sci-fi and fantasy, always drawn to stories that spark imagination and creativity.</p>
     <p>My professional life is about technology and reliability. My personal life is about growth, creativity, and family. Together, they shape how I approach every challenge—with focus, discipline, and curiosity.</p>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -15,24 +15,25 @@
       <a href="/about">About</a>
     </nav>
   </header>
-  <main class="centered">
-    <div id="game-container">
-      <div id="terminal"></div>
-      <form id="command-form">
-        <span>$</span>
-        <input id="command" autocomplete="off" autofocus />
-      </form>
-      <div id="hotkeys">
-        <button data-cmd="open overview" type="button">Overview</button>
-        <button data-cmd="open experience" type="button">Experience</button>
-        <button data-cmd="open projects" type="button">Projects</button>
-        <button data-cmd="open education" type="button">Education</button>
-        <!-- Certifications shortcut -->
-        <button data-cmd="open certifications" type="button">Certifications</button>
-        <button data-cmd="help" type="button">Help</button>
+    <main class="centered">
+      <h1 class="cli-title">Resume CLI</h1>
+      <div id="game-container">
+        <div id="terminal"></div>
+        <form id="command-form">
+          <span>$</span>
+          <input id="command" autocomplete="off" autofocus />
+        </form>
+        <div id="hotkeys">
+          <button data-cmd="open overview" type="button">Overview</button>
+          <button data-cmd="open experience" type="button">Experience</button>
+          <button data-cmd="open projects" type="button">Projects</button>
+          <button data-cmd="open education" type="button">Education</button>
+          <!-- Certifications shortcut -->
+          <button data-cmd="open certifications" type="button">Certifications</button>
+          <button data-cmd="help" type="button">Help</button>
+        </div>
       </div>
-    </div>
-  </main>
+    </main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -65,11 +65,16 @@ a:hover {
 }
 
 main.centered {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  background: none;
-  box-shadow: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    background: none;
+    box-shadow: none;
+}
+
+.cli-title {
+  margin-bottom: 1rem;
 }
 
 /* CLI container styling */
@@ -165,8 +170,16 @@ button {
 }
 
 button:hover {
-  background: #00ffff;
-  color: #000;
+    background: #00ffff;
+    color: #000;
+  }
+
+.photo-placeholder {
+  width: 200px;
+  height: 200px;
+  background: #fff;
+  border: 1px solid #ccc;
+  margin: 1rem auto;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- Clarify list navigation instructions so users can enter an item's number directly
- Flesh out the secret admin arena description with richer atmosphere
- Add a visible title to the CLI page and a photo placeholder on the About page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5e1f3aaf88322870c983d40e0d8dc