### PR TITLE
Improve CLI messaging and dynamic resume date

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Resume CLI</title>
+  <title>CLIndemood's CLI Resume</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -16,7 +16,7 @@
     </nav>
   </header>
     <main class="centered">
-      <h1 class="cli-title">Resume CLI</h1>
+      <h1 class="cli-title">CLIndemood's CLI Resume</h1>
       <div id="game-container">
         <div id="terminal"></div>
         <form id="command-form">


### PR DESCRIPTION
## Summary
- Replace "type the number" with `<id>` in list navigation hints
- Rename page title to "CLIndemood's CLI Resume"
- Calculate resume's last updated date from git history or file modification

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5e41513cc8322a71f5d6476f5cd2a