### PR TITLE
Refine about page and project metadata

### DIFF
--- a/app/filesystem.json
+++ b/app/filesystem.json
@@ -38,11 +38,7 @@
           "content": "Deployed a pfSense firewall and connected it to both Windows and Linux VMs.\nConfigured stateful firewall rules, VLAN segmentation, and port forwarding.\nIntegrated Suricata IDS to monitor for malicious traffic patterns.\nTested security by running controlled nmap scans and logging alerts.",
           "type": "file"
         },
-        "2024-01-network-automation-monitoring.txt": {
-          "content": "Built a small lab with Cisco IOSv routers in EVE-NG.\nUsed Python and Ansible playbooks to push standardized configs across devices.\nEnabled SNMP and Syslog exports to a central monitoring server.\nCreated dashboards in Grafana to visualize uptime, interface errors, and CPU utilization.",
-          "type": "file"
-        },
-        "2025-09-advanced-cisco-enterprise-network-lab.txt": {
+        "2025-07-advanced-cisco-enterprise-network-lab.txt": {
           "content": "Built an advanced EVE-NG topology simulating a branch office network.\nConfigured dynamic routing with OSPF, inter-VLAN routing, and port security.\nImplemented SNMP monitoring and Syslog forwarding.\nValidated resiliency by simulating link failures and verifying failover.",
           "type": "file"
         },

--- a/app/resume.json
+++ b/app/resume.json
@@ -250,29 +250,11 @@
       "id": 6,
       "name": "Advanced Cisco Enterprise Network Lab",
       "role": "Author",
-      "start": "2025-09",
+      "start": "2025-07",
       "tech": [
         "EVE-NG",
         "OSPF",
         "SNMP"
-      ]
-    },
-    {
-      "bullets": [
-        "Built a small lab with Cisco IOSv routers in EVE-NG.",
-        "Used Python and Ansible playbooks to push standardized configs across devices.",
-        "Enabled SNMP and Syslog exports to a central monitoring server.",
-        "Created dashboards in Grafana to visualize uptime, interface errors, and CPU utilization."
-      ],
-      "id": 5,
-      "name": "Network Automation and Monitoring Project",
-      "role": "Author",
-      "start": "2024-01",
-      "tech": [
-        "EVE-NG",
-        "Cisco IOSv",
-        "Ansible",
-        "Grafana"
       ]
     },
     {

--- a/app/static/about.html
+++ b/app/static/about.html
@@ -16,11 +16,15 @@
     </nav>
   </header>
   <main>
-    <h1>About Me</h1>
-      <div class="photo-placeholder"></div>
-    <p>I’m an IT professional with a background that ranges from service in the U.S. Air Force to supporting businesses through complex technical challenges. Over the years I’ve built a career around solving problems, improving systems, and helping teams work more securely and efficiently.</p>
-    <p>Beyond work, I’m a father first. My two boys, Damien (14) and Dimitri (8), keep me motivated and grounded. When I’m not troubleshooting servers or configuring networks, you’ll find me in the gym, on a motorcycle, or in the garage working on woodworking and laser engraving projects. I’m also an avid reader of sci-fi and fantasy, always drawn to stories that spark imagination and creativity.</p>
-    <p>My professional life is about technology and reliability. My personal life is about growth, creativity, and family. Together, they shape how I approach every challenge—with focus, discipline, and curiosity.</p>
+      <h1>About Me</h1>
+      <div class="about-content">
+        <div class="about-text">
+          <p>I’m an IT professional with a background that ranges from service in the U.S. Air Force to supporting businesses through complex technical challenges. Over the years I’ve built a career around solving problems, improving systems, and helping teams work more securely and efficiently.</p>
+          <p>Beyond work, I’m a father first. My two boys, Damien (14) and Dimitri (8), keep me motivated and grounded. When I’m not troubleshooting servers or configuring networks, you’ll find me in the gym, on a motorcycle, or in the garage working on woodworking and laser engraving projects. I’m also an avid reader of sci-fi and fantasy, always drawn to stories that spark imagination and creativity.</p>
+          <p>My professional life is about technology and reliability. My personal life is about growth, creativity, and family. Together, they shape how I approach every challenge—with focus, discipline, and curiosity.</p>
+        </div>
+        <div class="photo-placeholder">Headshot<br />Placeholder</div>
+      </div>
   </main>
   <footer>
     <p>&copy; 2024 Chad Lindemood</p>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>CLIndemood's CLI Resume</title>
+  <title>Chad Lindemood Interactive Resume</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -16,7 +16,7 @@
     </nav>
   </header>
     <main class="centered">
-      <h1 class="cli-title">CLIndemood's CLI Resume</h1>
+      <h1 class="cli-title">Chad Lindemood Interactive Resume</h1>
       <div id="game-container">
         <div id="terminal"></div>
         <form id="command-form">

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -189,12 +189,26 @@ button:hover {
     color: #000;
   }
 
+.about-content {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.about-text {
+  flex: 1;
+}
+
 .photo-placeholder {
   width: 200px;
   height: 200px;
   background: #fff;
   border: 1px solid #ccc;
-  margin: 1rem auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  flex-shrink: 0;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- reposition headshot placeholder to the right of the About text
- retitle homepage to "Chad Lindemood Interactive Resume"
- remove Network Automation and Monitoring project and set Advanced Cisco lab date to July 2025

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5e90510588322a43937eaf1aeeca7