### PR TITLE
Retro title styling and remove Suricata bullet

### DIFF
--- a/app/filesystem.json
+++ b/app/filesystem.json
@@ -35,7 +35,7 @@
           "type": "file"
         },
         "2023-06-firewall-intrusion-detection-lab.txt": {
-          "content": "Deployed a pfSense firewall and connected it to both Windows and Linux VMs.\nConfigured stateful firewall rules, VLAN segmentation, and port forwarding.\nIntegrated Suricata IDS to monitor for malicious traffic patterns.\nTested security by running controlled nmap scans and logging alerts.",
+          "content": "Deployed a pfSense firewall and connected it to both Windows and Linux VMs.\nConfigured stateful firewall rules, VLAN segmentation, and port forwarding.\nTested security by running controlled nmap scans and logging alerts.",
           "type": "file"
         },
         "2025-07-advanced-cisco-enterprise-network-lab.txt": {

--- a/app/resume.json
+++ b/app/resume.json
@@ -261,7 +261,6 @@
       "bullets": [
         "Deployed a pfSense firewall and connected it to both Windows and Linux VMs.",
         "Configured stateful firewall rules, VLAN segmentation, and port forwarding.",
-        "Integrated Suricata IDS to monitor for malicious traffic patterns.",
         "Tested security by running controlled nmap scans and logging alerts."
       ],
       "id": 4,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Chad Lindemood Interactive Resume</title>
+  <title>Interactive Resume Terminal</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -16,7 +16,7 @@
     </nav>
   </header>
     <main class="centered">
-      <h1 class="cli-title">Chad Lindemood Interactive Resume</h1>
+      <h1 class="cli-title">Interactive Resume Terminal</h1>
       <div id="game-container">
         <div id="terminal"></div>
         <form id="command-form">

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=VT323&display=swap');
+
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
   background: #f5f7fa;
@@ -75,6 +77,10 @@ main.centered {
 
 .cli-title {
   margin-bottom: 1rem;
+  font-family: 'VT323', monospace;
+  font-size: 2.5rem;
+  color: #33ff33;
+  text-shadow: 0 0 5px #33ff33, 0 0 10px #00ffff;
 }
 
 /* CLI container styling */


### PR DESCRIPTION
## Summary
- Replace “Chad Lindemood Interactive Resume” header with new “Interactive Resume Terminal” wording
- Add retro terminal font and neon styling for the CLI title
- Drop Suricata IDS bullet from Firewall and Intrusion Detection Lab project data

## Testing
- `python -m py_compile app/main.py`
- `python -m json.tool app/resume.json`
- `python -m json.tool app/filesystem.json`


------
https://chatgpt.com/codex/tasks/task_e_68c5eb76ec508322b593ada7a718b7a8