### PR TITLE
Improve terminal title and MDF defeat text

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -401,8 +401,10 @@ def handle_secret_game(state: Dict[str, Any], command: str, args: List[str]) -> 
                 game["equipment"].append(loot)
                 if target_key == "printer":
                     lines.append(f"The printer jams one last time and erupts in a cloud of toner! Loot: {loot}.")
+                elif target_key == "server":
+                    lines.append(f"The server blue-screens! Loot: {loot}.")
                 else:
-                    lines.append(f"The {target_key} blue-screens! Loot: {loot}.")
+                    lines.append(f"The MDF short-circuits! Loot: {loot}.")
                 game["enemy_hp"][target_key] = 0
                 break
             enemy_hit = random.randint(1, 5)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -75,6 +75,13 @@ main.centered {
 
 .cli-title {
   margin-bottom: 1rem;
+  font-family: monospace;
+  color: #33ff33;
+  background: #000;
+  padding: 0.5rem 1rem;
+  border: 1px solid #00ffff;
+  display: inline-block;
+  text-shadow: 0 0 5px #33ff33;
 }
 
 /* CLI container styling */


### PR DESCRIPTION
## Summary
- Style CLI title with terminal-like monospace, green text, and black background
- Replace MDF blue-screen message with short-circuit flavor text

## Testing
- `python -m py_compile app/main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5ede5a5988322b184fc03de18a7fe