### PR TITLE
Tweak layout spacing for header and about photo

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -13,7 +13,7 @@ header {
   background: linear-gradient(135deg, #2c3e50, #4ca1af);
   color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  padding: 1rem 0;
+  padding: 0.5rem 0;
 }
 
 nav {
@@ -71,7 +71,7 @@ main.centered {
     align-items: center;
     background: none;
     box-shadow: none;
-    margin: 1rem auto;
+    margin: 0.5rem auto;
 }
 
 .cli-title {
@@ -214,6 +214,7 @@ button:hover {
   border: 1px solid #ccc;
   object-fit: cover;
   flex-shrink: 0;
+  margin-top: 1rem;
 }
 
 footer {


### PR DESCRIPTION
## Summary
- Reduce header padding and centered main margin to tighten space between nav links and title
- Add top margin to about page headshot for better alignment with text

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5fd7a337c8322be0a2d1ad9cc7229