### PR TITLE
build: add Dockerfile and document container usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+Thanks for your interest in improving the resume site! The project is small and light on tooling, so contributions are straightforward.
+
+## Set up your environment
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv && source .venv/bin/activate
+   pip install -r requirements.txt  # or pip install fastapi uvicorn
+   ```
+2. Run the server locally to confirm things work:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+## Editing resume data
+
+The site's content lives in JSON files under `app/`.
+
+- Keep keys sorted for readability.
+- After editing, format the JSON to ensure deterministic output:
+  ```bash
+  jq --sort-keys '.' app/resume.json > tmp && mv tmp app/resume.json
+  jq --sort-keys '.' app/filesystem.json > tmp && mv tmp app/filesystem.json
+  ```
+
+## Tests
+
+Run tests before submitting changes:
+```bash
+pytest
+```
+
+## Pull requests
+
+- Use descriptive commit messages.
+- Open a pull request with a summary of your changes and mention any open questions.
+- Ensure the site still runs locally and tests pass.
+
+Thanks for helping out!

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,22 @@
+# Deployment
+
+This project can be hosted on AWS in a few different ways. Below are two common approaches.
+
+## Option A – Single container/EC2
+
+1. Build the included `Dockerfile` and push the image to Amazon ECR.
+2. Run the container on ECS Fargate or an EC2 instance behind an ALB.
+3. Expose port 80/443 and point your domain to the load balancer.
+
+## Option B – Static hosting + serverless API
+
+1. Upload files under `app/static/` to an S3 bucket configured for static website hosting or fronted by CloudFront.
+2. Package the FastAPI app for AWS Lambda using [Mangum](https://github.com/jordaneremieff/mangum) or a similar ASGI adapter.
+3. Deploy the function behind API Gateway with endpoints under `/api/*` and enable CORS for your static site's origin.
+4. Update any front-end code if the API lives on a different domain.
+
+## General notes
+
+- Include the JSON data files in your deployment artifact so the API can load resume content.
+- No external database is required; sessions are kept in memory.
+- Use CloudWatch Logs or similar monitoring to track runtime errors and access logs.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir fastapi uvicorn
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
 # Resume Site
 
-This repository powers an interactive resume and portfolio site.
+This repository powers an interactive resume and portfolio site built with FastAPI and vanilla HTML/JS.
+
+## Running locally
+
+1. Create a virtual environment and install dependencies:
+   ```bash
+   python -m venv .venv && source .venv/bin/activate
+   pip install fastapi uvicorn
+   ```
+2. Launch the development server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+3. Visit <http://localhost:8000/> to browse the site.
+
+## Running with Docker
+
+1. Build the image:
+   ```bash
+   docker build -t resume-site .
+   ```
+2. Run the container:
+   ```bash
+   docker run -p 8000:8000 resume-site
+   ```
+3. Open <http://localhost:8000/> in your browser.
 
 ## Updating resume data
 
@@ -18,4 +43,12 @@ The site reads its resume information from JSON files under `app/`.
    pytest
    ```
 5. Commit and deploy the changes.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on formatting JSON and submitting changes.
+
+## Deployment
+
+Deployment options and AWS hosting instructions are covered in [DEPLOYMENT.md](DEPLOYMENT.md).
 


### PR DESCRIPTION
## Summary
- provide Dockerfile to run the FastAPI resume site in containers
- document Docker build/run commands in README
- update deployment guide to reference included Dockerfile

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c60282a9788322876a699b2559b300