### PR TITLE
Add tests for key API routes

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,19 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_root_returns_200():
+    response = client.get("/")
+    assert response.status_code == 200
+
+
+def test_projects_returns_200():
+    response = client.get("/projects")
+    assert response.status_code == 200
+
+
+def test_api_resume_returns_200():
+    response = client.get("/api/resume")
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add basic tests ensuring root, projects, and resume API endpoints return HTTP 200

## Testing
- `pytest tests/test_routes.py -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c6080e4aa08322bd6138097ed4be65