### PR TITLE
test: cover additional routes and CLI flow

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -17,3 +17,44 @@ def test_projects_returns_200():
 def test_api_resume_returns_200():
     response = client.get("/api/resume")
     assert response.status_code == 200
+
+
+def test_education_returns_200():
+    response = client.get("/education")
+    assert response.status_code == 200
+
+
+def test_about_returns_200():
+    response = client.get("/about")
+    assert response.status_code == 200
+
+
+def test_resume_returns_200():
+    response = client.get("/resume")
+    assert response.status_code == 200
+
+
+def test_api_start_and_command_flow():
+    start_resp = client.get("/api/start")
+    assert start_resp.status_code == 200
+    data = start_resp.json()
+    assert "session_id" in data
+    session_id = data["session_id"]
+
+    open_resp = client.post(
+        "/api/command", json={"session_id": session_id, "command": "open overview"}
+    )
+    assert open_resp.status_code == 200
+    assert "Name:" in open_resp.json()["text"]
+
+    next_resp = client.post(
+        "/api/command", json={"session_id": session_id, "command": "next"}
+    )
+    assert next_resp.status_code == 200
+    assert "Name:" in next_resp.json()["text"]
+
+    invalid_resp = client.post(
+        "/api/command", json={"session_id": session_id, "command": "999"}
+    )
+    assert invalid_resp.status_code == 200
+    assert invalid_resp.json()["text"] == "Unknown id."


### PR DESCRIPTION
## Summary
- add tests for education, about, and resume endpoints
- simulate CLI session with /api/start and /api/command
- verify handling of pagination and invalid IDs

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.103.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68c60b700ce483228e1c191da007085b