### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt pytest httpx
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
## Summary
- run pytest in CI on pushes and PRs to main
- cache pip downloads
- ensure httpx is installed for tests

## Testing
- `pip install httpx` *(fails: Could not connect to proxy)*
- `pytest` *(fails: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c60c315f5c83228991f4905ce39f6d