### PR TITLE
Add session TTL with optional Redis store

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository powers an interactive resume and portfolio site built with FastA
 1. Create a virtual environment and install dependencies:
    ```bash
    python -m venv .venv && source .venv/bin/activate
-   pip install fastapi uvicorn
+   pip install -r requirements.txt
    ```
 2. Launch the development server:
    ```bash
@@ -26,6 +26,12 @@ This repository powers an interactive resume and portfolio site built with FastA
    docker run -p 8000:8000 resume-site
    ```
 3. Open <http://localhost:8000/> in your browser.
+
+### Session storage
+
+Sessions are stored in memory and automatically pruned after ``SESSION_TTL`` seconds
+(default: 3600).  For horizontal scalability you can provide a Redis instance by
+setting ``SESSION_REDIS_URL``.
 
 ## Updating resume data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.103.2
 uvicorn==0.23.2
+redis==5.0.1

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -58,3 +58,13 @@ def test_api_start_and_command_flow():
     )
     assert invalid_resp.status_code == 200
     assert invalid_resp.json()["text"] == "Unknown id."
+
+
+def test_prune_sessions_removes_old():
+    from app.main import SESSION_TTL, prune_sessions, sessions
+    import time
+
+    old_id = "expired"
+    sessions[old_id] = {"_ts": time.time() - (SESSION_TTL + 1)}
+    prune_sessions()
+    assert old_id not in sessions


### PR DESCRIPTION
## Summary
- track last activity timestamp for sessions
- periodically prune expired sessions and allow Redis-backed storage
- document session management and add regression test

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement redis==5.0.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c60d2dbabc832292858866377c93df