### PR TITLE
Run container as non-root with configurable port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,14 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy application code
 COPY . .
+ 
+RUN adduser --disabled-password --gecos "" appuser \
+    && chown -R appuser:appuser /app
 
-EXPOSE 8000
+ENV PORT=8000
+EXPOSE $PORT
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+USER appuser
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "$PORT"]
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ This repository powers an interactive resume and portfolio site built with FastA
    ```bash
    docker run -p 8000:8000 resume-site
    ```
-3. Open <http://localhost:8000/> in your browser.
+   The server listens on the port specified by the `PORT` environment variable, which
+   defaults to `8000`. To use a different port, set `PORT` and publish the same port:
+   ```bash
+   docker run -e PORT=8080 -p 8080:8080 resume-site
+   ```
+3. Open <http://localhost:8000/> in your browser (replace `8000` with the value of `PORT` if changed).
 
 ### Session storage
 


### PR DESCRIPTION
## Summary
- Create `appuser` non-root user for container images
- Expose configurable `PORT` env variable and use it in server startup
- Document `PORT` environment variable for Docker usage

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c60e72e90c832280575616062f7248