### PR TITLE
Add Terraform infrastructure for ECS deployment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -39,6 +39,32 @@ This project can be hosted on AWS in a few different ways. Below are two common 
    aws route53 change-resource-record-sets --hosted-zone-id <zone-id> --change-batch file://dns.json
    ```
 
+## Infrastructure as Code
+
+Infrastructure resources for running the container on ECS Fargate are codified
+under the [`infra/`](infra) directory using Terraform. The configuration
+creates an ECR repository, ECS cluster and service, an Application Load
+Balancer, and Route53 records.
+
+Example usage:
+
+```bash
+cd infra
+terraform init
+terraform apply \
+  -var="aws_region=us-east-1" \
+  -var="aws_account_id=123456789012" \
+  -var="domain_name=example.com" \
+  -var="certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/abc"
+
+# When finished
+terraform destroy \
+  -var="aws_region=us-east-1" \
+  -var="aws_account_id=123456789012" \
+  -var="domain_name=example.com" \
+  -var="certificate_arn=arn:aws:acm:us-east-1:123456789012:certificate/abc"
+```
+
 ## Option B – Static hosting + serverless API
 
 1. Upload files under `app/static/` to an S3 bucket configured for static website hosting or fronted by CloudFront.

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,213 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+locals {
+  repository_url = "${var.aws_account_id}.dkr.ecr.${var.aws_region}.amazonaws.com/${aws_ecr_repository.app.name}"
+}
+
+resource "aws_ecr_repository" "app" {
+  name = "resume-site"
+}
+
+resource "aws_ecs_cluster" "main" {
+  name = "resume-cluster"
+}
+
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution" {
+  name               = "resume-task-execution"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_execution" {
+  role       = aws_iam_role.task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name   = "resume-alb-sg"
+  vpc_id = data.aws_vpc.default.id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_lb" "app" {
+  name               = "resume-alb"
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = data.aws_subnets.default.ids
+}
+
+resource "aws_lb_target_group" "app" {
+  name       = "resume-tg"
+  port       = 80
+  protocol   = "HTTP"
+  vpc_id     = data.aws_vpc.default.id
+  target_type = "ip"
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = aws_lb.app.arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}
+
+resource "aws_security_group" "ecs" {
+  name   = "resume-ecs-sg"
+  vpc_id = data.aws_vpc.default.id
+
+  ingress {
+    from_port       = 80
+    to_port         = 80
+    protocol        = "tcp"
+    security_groups = [aws_security_group.alb.id]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "resume-site"
+  cpu                      = "256"
+  memory                   = "512"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.task_execution.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "resume-site"
+      image     = "${local.repository_url}:latest"
+      essential = true
+      portMappings = [{
+        containerPort = 80
+        hostPort      = 80
+      }]
+    }
+  ])
+}
+
+resource "aws_ecs_service" "app" {
+  name            = "resume-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = data.aws_subnets.default.ids
+    security_groups = [aws_security_group.ecs.id]
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.app.arn
+    container_name   = "resume-site"
+    container_port   = 80
+  }
+
+  depends_on = [aws_lb_listener.https]
+}
+
+data "aws_route53_zone" "main" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+resource "aws_route53_record" "app" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.app.dns_name
+    zone_id                = aws_lb.app.zone_id
+    evaluate_target_health = true
+  }
+}
+
+output "repository_url" {
+  description = "URL of the ECR repository"
+  value       = local.repository_url
+}
+
+output "load_balancer_dns" {
+  description = "DNS name of the created load balancer"
+  value       = aws_lb.app.dns_name
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID used for constructing repository URLs"
+  type        = string
+}
+
+variable "domain_name" {
+  description = "Domain name for Route53 record"
+  type        = string
+}
+
+variable "certificate_arn" {
+  description = "ARN of the ACM certificate for HTTPS"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add Terraform setup for ECR repo, ECS Fargate service, ALB, and Route53 record
- document Terraform usage and variables in deployment guide

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `terraform fmt` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c60f2430088322be0f4b4cea169d96