### PR TITLE
Expose FastAPI app in package init

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]


### PR DESCRIPTION
## Summary
- expose FastAPI `app` object at package root for easier imports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Could not connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c612e2ca2c8322b127a8ae3dda7a1e