### PR TITLE
Ensure tests can import app package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.103.2
 uvicorn==0.23.2
 redis==5.0.1
+httpx==0.24.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so that `import app` works when tests
+# are executed from a different working directory or when Python does not
+# automatically include the current directory on the module search path.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- Add `tests/conftest.py` to place project root on `sys.path`
- Include `httpx` in `requirements.txt` to satisfy FastAPI test client dependency

## Testing
- `python -m pytest tests/test_routes.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c613bc93e08322874e2ed7b5bf11a3