### PR TITLE
Add health route and ALB health check

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -823,6 +823,10 @@ COMMAND_HELP = {
 # HTTP routes
 # ---------------------------------------------------------------------------
 
+@app.get("/health")
+def health() -> Dict[str, str]:
+    return {"status": "ok"}
+
 @app.get("/", response_class=FileResponse)
 def index() -> FileResponse:
     return FileResponse(STATIC_DIR / "index.html")

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -93,6 +93,11 @@ resource "aws_lb_target_group" "app" {
   protocol   = "HTTP"
   vpc_id     = data.aws_vpc.default.id
   target_type = "ip"
+
+  health_check {
+    path    = "/health"
+    matcher = "200"
+  }
 }
 
 resource "aws_lb_listener" "http" {

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -34,6 +34,11 @@ def test_resume_returns_200():
     assert response.status_code == 200
 
 
+def test_health_returns_200():
+    response = client.get("/health")
+    assert response.status_code == 200
+
+
 def test_api_start_and_command_flow():
     start_resp = client.get("/api/start")
     assert start_resp.status_code == 200


### PR DESCRIPTION
## Summary
- expose `/health` endpoint returning OK
- add ALB target group health check for `/health`
- cover new health endpoint with test

## Testing
- `terraform fmt -check` *(fails: command not found)*
- `pytest` *(fails: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68c615c840588322b2360a66574fcbe5