### PR TITLE
Add CloudWatch logging for ECS task

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -147,6 +147,11 @@ resource "aws_security_group" "ecs" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/resume-site"
+  retention_in_days = 30
+}
+
 resource "aws_ecs_task_definition" "app" {
   family                   = "resume-site"
   cpu                      = "256"
@@ -164,6 +169,14 @@ resource "aws_ecs_task_definition" "app" {
         containerPort = 8000
         hostPort      = 8000
       }]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.app.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "ecs"
+        }
+      }
     }
   ])
 }


### PR DESCRIPTION
## Summary
- create CloudWatch log group for ECS task with 30-day retention
- send container logs to log group via awslogs driver

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `terraform fmt -check infra/main.tf` *(fails: command not found)*
- `terraform validate` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c616d55cdc8322ad5a5f23ab95ed5f