### PR TITLE
Configure session settings via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ This repository powers an interactive resume and portfolio site built with FastA
    ```
 3. Open <http://localhost:8000/> in your browser (replace `8000` with the value of `PORT` if changed).
 
-### Session storage
+## Environment variables
 
-Sessions are stored in memory and automatically pruned after ``SESSION_TTL`` seconds
-(default: 3600).  For horizontal scalability you can provide a Redis instance by
-setting ``SESSION_REDIS_URL``.
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `PORT` | `8000` | Port that the server listens on. |
+| `SESSION_TTL` | `3600` | Session expiration time in seconds. |
+| `SESSION_REDIS_URL` | _(none)_ | Redis connection URL for session storage. Provide this when deploying to share sessions across multiple tasks. |
+
+When deploying, ensure `SESSION_REDIS_URL` is set so sessions can be shared across multiple tasks.
 
 ## Updating resume data
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -177,6 +177,22 @@ resource "aws_ecs_task_definition" "app" {
           "awslogs-stream-prefix" = "ecs"
         }
       }
+      environment = [
+        {
+          name  = "PORT"
+          value = "8000"
+        },
+        {
+          name  = "SESSION_TTL"
+          value = "3600"
+        }
+      ]
+      secrets = [
+        {
+          name      = "SESSION_REDIS_URL"
+          valueFrom = var.session_redis_url
+        }
+      ]
     }
   ])
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -17,3 +17,8 @@ variable "certificate_arn" {
   description = "ARN of the ACM certificate for HTTPS"
   type        = string
 }
+
+variable "session_redis_url" {
+  description = "ARN of the secret or SSM parameter containing the Redis URL for session storage"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- expose port and session settings in ECS container definition
- document PORT, SESSION_TTL and SESSION_REDIS_URL

## Testing
- `terraform fmt` *(command not found)*
- `terraform init -backend=false` *(not run; Terraform unavailable)*
- `terraform validate` *(not run; Terraform unavailable)*
- `pytest` *(missing httpx dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c617618d3c83228b4119bb8d78fa25