### PR TITLE
Add session cookies and CSRF protection

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -1,4 +1,4 @@
-let sessionId; // current CLI session identifier returned by the backend
+let csrfToken; // CSRF token provided by the backend
 const terminal = document.getElementById('terminal');
 const form = document.getElementById('command-form');
 const input = document.getElementById('command');
@@ -44,7 +44,7 @@ function print(text, cls = 'output') {
 async function start() {
   const res = await fetch('/api/start');
   const data = await res.json();
-  sessionId = data.session_id;
+  csrfToken = data.csrf_token;
   if (data.ascii_art) {
     print(data.ascii_art, 'ascii');
   }
@@ -55,8 +55,8 @@ async function start() {
 async function sendCommand(cmd) {
   const res = await fetch('/api/command', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ session_id: sessionId, command: cmd })
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrfToken },
+    body: JSON.stringify({ command: cmd })
   });
   const data = await res.json();
   print('$ ' + cmd, 'input');

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -43,23 +43,24 @@ def test_api_start_and_command_flow():
     start_resp = client.get("/api/start")
     assert start_resp.status_code == 200
     data = start_resp.json()
-    assert "session_id" in data
-    session_id = data["session_id"]
+    assert "csrf_token" in data
+    csrf = data["csrf_token"]
+    assert "session_id" in start_resp.cookies
 
     open_resp = client.post(
-        "/api/command", json={"session_id": session_id, "command": "open overview"}
+        "/api/command", json={"command": "open overview"}, headers={"X-CSRF-Token": csrf}
     )
     assert open_resp.status_code == 200
     assert "Name:" in open_resp.json()["text"]
 
     next_resp = client.post(
-        "/api/command", json={"session_id": session_id, "command": "next"}
+        "/api/command", json={"command": "next"}, headers={"X-CSRF-Token": csrf}
     )
     assert next_resp.status_code == 200
     assert "Name:" in next_resp.json()["text"]
 
     invalid_resp = client.post(
-        "/api/command", json={"session_id": session_id, "command": "999"}
+        "/api/command", json={"command": "999"}, headers={"X-CSRF-Token": csrf}
     )
     assert invalid_resp.status_code == 200
     assert invalid_resp.json()["text"] == "Unknown id."


### PR DESCRIPTION
## Summary
- validate CLI requests with Pydantic models
- issue session IDs via HttpOnly cookies and require CSRF tokens
- adapt frontend and tests for cookie-based sessions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c61aa9dea083228b15a612710d2e4e