### PR TITLE
Ignore non-runtime directories in Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,6 +18,11 @@ ENV/
 pytest_cache/
 coverage/
 
+# Non-runtime directories
+tests/
+.github/
+infra/
+
 # IDE and OS files
 .vscode/
 .idea/


### PR DESCRIPTION
## Summary
- Exclude test, CI, and infrastructure directories from Docker build context

## Testing
- `pytest`
- `docker build -t resume-site:latest .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c61d69409c8322949192ab74ed1d2c