### PR TITLE
Optimize Docker image and enforce read-only filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
-FROM python:3.11-slim
+FROM python:3.11-slim AS build
 
 WORKDIR /app
 
-# Install dependencies
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
 
-# Copy application code
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+
+COPY --from=build /usr/local /usr/local
 COPY . .
- 
+
 RUN adduser --disabled-password --gecos "" appuser \
     && chown -R appuser:appuser /app
 
@@ -18,4 +23,3 @@ EXPOSE $PORT
 USER appuser
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "$PORT"]
-

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -165,6 +165,7 @@ resource "aws_ecs_task_definition" "app" {
       name      = "resume-site"
       image     = "${local.repository_url}:latest"
       essential = true
+      readonlyRootFilesystem = true
       portMappings = [{
         containerPort = 8000
         hostPort      = 8000


### PR DESCRIPTION
## Summary
- Use multi-stage Docker build, upgrade pip, and set Python bytecode and buffering controls
- Enforce a read-only root filesystem in the ECS task definition

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c61e0e1b0083229475f697ef75c832