### PR TITLE
Add pre-commit and dependency security scanning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pytest httpx
+          pip install -r requirements.txt pytest httpx pre-commit pip-audit
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color always --all-files
+      - name: Scan dependencies
+        run: pip-audit -r requirements.txt
       - name: Run tests
         run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.12.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.4
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        args: [-q, -r, app]


### PR DESCRIPTION
## Summary
- configure pre-commit with Black, Ruff, and Bandit
- run pre-commit and pip-audit in CI for linting and dependency vulnerability checks

## Testing
- `pytest`
- ⚠️ `pre-commit run --all-files` *(pre-commit not installed)*
- ⚠️ `pip-audit -r requirements.txt` *(pip-audit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c61f0826848322a199a4c6f6b0ebde