### PR TITLE
Add session and XSS security regression tests

### DIFF
--- a/tests/test_session_csrf_command.py
+++ b/tests/test_session_csrf_command.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+from app import main
+
+
+def test_session_expires_after_ttl():
+    client = TestClient(main.app)
+    start = client.get("/api/start", headers={"X-Forwarded-For": "198.51.100.99"})
+    csrf = start.json()["csrf_token"]
+    sid = start.cookies["session_id"]
+    # make session appear expired
+    main.sessions[sid]["_ts"] -= main.SESSION_TTL + 1
+    main.prune_sessions()
+    resp = client.post(
+        "/api/command",
+        json={"command": "help"},
+        headers={"X-CSRF-Token": csrf},
+    )
+    assert resp.status_code == 400
+
+
+def test_csrf_token_must_match():
+    client = TestClient(main.app)
+    client.get("/api/start", headers={"X-Forwarded-For": "198.51.100.98"})
+    resp = client.post(
+        "/api/command",
+        json={"command": "help"},
+        headers={"X-CSRF-Token": "bad-token"},
+    )
+    assert resp.status_code == 403
+
+
+def test_invalid_command_parsing_returns_400():
+    client = TestClient(main.app)
+    start = client.get("/api/start", headers={"X-Forwarded-For": "198.51.100.97"})
+    csrf = start.json()["csrf_token"]
+    resp = client.post(
+        "/api/command",
+        json={"command": "open 'unterminated"},
+        headers={"X-CSRF-Token": csrf},
+    )
+    assert resp.status_code == 400

--- a/tests/test_xss_frontend.py
+++ b/tests/test_xss_frontend.py
@@ -1,0 +1,59 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+SCRIPT_PATH = Path("app/static/script.js").resolve()
+
+
+def run_js(function: str, argument: str) -> str:
+    js = f"""
+const fs=require('fs');
+const vm=require('vm');
+const path={json.dumps(str(SCRIPT_PATH))};
+const script=fs.readFileSync(path,'utf8');
+const stub={{
+  appendChild: ()=>{{}},
+  addEventListener: ()=>{{}},
+  scrollTop:0,
+  scrollHeight:0,
+  textContent:'',
+  value:'',
+  dataset:{{}}
+}};
+const document={{
+  getElementById: id => stub,
+  createElement: tag => ({{...stub}})
+}};
+const sandbox={{
+  console: console,
+  document: document,
+  window: {{}},
+  fetch: () => Promise.resolve({{ json: () => Promise.resolve({{}}) }}),
+  setTimeout: () => {{}},
+}};
+vm.createContext(sandbox);
+vm.runInContext(script, sandbox);
+const result = sandbox['{function}']({json.dumps(argument)});
+if (typeof result === 'string') {{
+  console.log(result);
+}} else {{
+  console.log(JSON.stringify(result));
+}}
+"""
+    completed = subprocess.run(["node", "-e", js], capture_output=True, text=True)
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout.strip()
+
+
+def test_escape_html_strips_tags():
+    output = run_js("escapeHtml", "<script>alert('x')</script>")
+    assert "<script>" not in output
+    assert "&lt;script&gt;" in output
+
+
+def test_colorize_escapes_html_before_highlighting():
+    payload = "<img src=x onerror=alert('xss')>"
+    output = run_js("colorize", payload)
+    assert "<img" not in output
+    assert "&lt;img src=x onerror=alert('xss')&gt;" in output


### PR DESCRIPTION
## Summary
- Ensure command endpoint returns 400 on invalid command syntax
- Add tests for session expiration and CSRF token checks
- Add regression tests for front-end XSS protections

## Testing
- `black tests/test_xss_frontend.py tests/test_session_csrf_command.py app/main.py`
- `ruff check tests/test_xss_frontend.py tests/test_session_csrf_command.py app/main.py`
- `pytest -q`
- `pre-commit run --files app/main.py tests/test_session_csrf_command.py tests/test_xss_frontend.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Cannot connect to proxy)*
- `bandit -q -r app` *(fails: command not found)*
- `pip install bandit` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c61fc6848483229e2b45831a179f83