### PR TITLE
Fix Bandit pre-commit dependency and format tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,4 @@ repos:
     hooks:
       - id: bandit
         args: [-q, -r, app]
+        additional_dependencies: [pbr]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -48,7 +48,9 @@ def test_api_start_and_command_flow():
     assert "session_id" in start_resp.cookies
 
     open_resp = client.post(
-        "/api/command", json={"command": "open overview"}, headers={"X-CSRF-Token": csrf}
+        "/api/command",
+        json={"command": "open overview"},
+        headers={"X-CSRF-Token": csrf},
     )
     assert open_resp.status_code == 200
     assert "Name:" in open_resp.json()["text"]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -19,6 +19,7 @@ def test_security_headers_present():
 def test_cors_respects_allowed_origins():
     os.environ["ALLOWED_ORIGINS"] = "https://allowed.example"
     import app.main as main
+
     importlib.reload(main)
 
     client = TestClient(main.app)


### PR DESCRIPTION
## Summary
- add missing `pbr` dependency to Bandit pre-commit hook
- format tests with Black

## Testing
- `python -m black tests/test_routes.py tests/test_security.py`
- `python -m ruff check tests/test_routes.py tests/test_security.py`
- `python -m bandit -q -r app` *(fails: No module named bandit)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6230293088322933529f8c597e175