### PR TITLE
Use safer git invocation for last updated metadata

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ import json
 import os
 import random
 import shlex
+import shutil
 import subprocess
 import time
 import uuid
@@ -59,16 +60,19 @@ with DATA_PATH.open() as f:
 
 
 def get_last_updated() -> str:
-    try:
-        return (
-            subprocess.check_output(
-                ["git", "log", "-1", "--format=%cs", str(DATA_PATH)]
+    git = shutil.which("git")
+    if git:
+        try:
+            result = subprocess.run(
+                [git, "log", "-1", "--format=%cs", str(DATA_PATH)],
+                check=True,
+                capture_output=True,
+                text=True,
             )
-            .decode()
-            .strip()
-        )
-    except Exception:
-        return datetime.fromtimestamp(DATA_PATH.stat().st_mtime).strftime("%Y-%m-%d")
+            return result.stdout.strip()
+        except (subprocess.CalledProcessError, OSError):
+            pass
+    return datetime.fromtimestamp(DATA_PATH.stat().st_mtime).strftime("%Y-%m-%d")
 
 
 RESUME.setdefault("meta", {})["last_updated"] = get_last_updated()


### PR DESCRIPTION
## Summary
- resolve absolute git path using `shutil.which`
- fetch last update date via `subprocess.run` with explicit argument list
- fall back to file modification time when git is unavailable or fails

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c62463614883229b20ee7664ff946b