### PR TITLE
Defer resume data loading until DOM ready

### DIFF
--- a/app/static/education.html
+++ b/app/static/education.html
@@ -24,9 +24,6 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
-    <script type="module">
-      import {loadEducation} from '/static/resume-data.js';
-      loadEducation();
-    </script>
+    <script type="module" src="/static/resume-data.js"></script>
   </body>
 </html>

--- a/app/static/projects.html
+++ b/app/static/projects.html
@@ -22,9 +22,6 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
-    <script type="module">
-      import {loadProjects} from '/static/resume-data.js';
-      loadProjects();
-    </script>
+    <script type="module" src="/static/resume-data.js"></script>
   </body>
 </html>

--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -249,3 +249,18 @@ export async function loadResume() {
     main.textContent = 'Could not load resume.';
   }
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.getElementById('resume-container')) {
+    loadResume();
+  }
+  if (document.getElementById('projects-list')) {
+    loadProjects();
+  }
+  if (
+    document.getElementById('education-list') ||
+    document.getElementById('certifications-list')
+  ) {
+    loadEducation();
+  }
+});

--- a/app/static/resume.html
+++ b/app/static/resume.html
@@ -19,9 +19,6 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
-    <script type="module">
-      import {loadResume} from '/static/resume-data.js';
-      loadResume();
-    </script>
+    <script type="module" src="/static/resume-data.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Initialize resume, project, and education sections after `DOMContentLoaded` only when their elements exist
- Replace inline module scripts with a shared `resume-data.js` module for all pages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62a721afc8322a70f2a3b3ed5f4f5