### PR TITLE
Check API status before parsing resume data

### DIFF
--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -1,6 +1,9 @@
 async function fetchResume() {
   try {
     const res = await fetch('/api/resume');
+    if (!res.ok) {
+      throw new Error(`Failed to fetch resume: ${res.status} ${res.statusText}`);
+    }
     return await res.json();
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
## Summary
- Ensure `fetchResume` verifies `fetch` response status before parsing
- Throw a descriptive error when the resume API request fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62aea24e48322b6fcbcaee3808ff9