### PR TITLE
refactor: defer resume initialization

### DIFF
--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -253,7 +253,7 @@ export async function loadResume() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+function init() {
   if (document.getElementById('resume-container')) {
     loadResume();
   }
@@ -266,4 +266,10 @@ document.addEventListener('DOMContentLoaded', () => {
   ) {
     loadEducation();
   }
-});
+}
+
+if (document.readyState !== 'loading') {
+  init();
+} else {
+  document.addEventListener('DOMContentLoaded', init);
+}


### PR DESCRIPTION
## Summary
- wrap resume element checks in an `init` function
- run `init` immediately or on `DOMContentLoaded` depending on document readiness

## Testing
- ⚠️ `pre-commit run --files app/static/resume-data.js` (pre-commit: command not found)
- ✅ `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c62db974548322a1c43017cefb7720