### PR TITLE
Highlight Azure credentials and deployments

### DIFF
--- a/app/filesystem.json
+++ b/app/filesystem.json
@@ -5,7 +5,7 @@
       "type": "file"
     },
     "certifications.txt": {
-      "content": "Cisco Certified Network Associate; Microsoft Azure Administrator (AZ-104); AWS Certified Cloud Practitioner; CompTIA A+ (220-1101 + 220-1102); CompTIA Network+ (N10-008); CompTIA Security+ (SY0-601); Microsoft SC-900; Microsoft Azure Data Fundamentals (DP-900); ITIL 4.",
+      "content": "Cisco Certified Network Associate; Microsoft Azure Administrator (AZ-104); Microsoft Azure Fundamentals (AZ-900); CompTIA A+ (220-1101 + 220-1102); CompTIA Network+ (N10-008); CompTIA Security+ (SY0-601); Microsoft SC-900; Microsoft Azure Data Fundamentals (DP-900); ITIL 4.",
       "type": "file"
     },
     "contact.txt": {
@@ -43,7 +43,7 @@
           "type": "file"
         },
         "2025-09-resume-creation-lab.txt": {
-          "content": "Created an interactive lab using AI tools to build a resume-focused website.\nContainerized the application with Docker and orchestrated it using Kubernetes.\nDeployed the site to Azure for public access and scalability testing.\nThis is that website!",
+          "content": "Created an interactive lab using AI tools to build a resume-focused website.\nContainerized the application with Docker and orchestrated it using Azure Kubernetes Service (AKS).\nDeployed the site to Azure for public access and scalability testing.\nThis is that website!",
           "type": "file"
         }
       },

--- a/app/resume.json
+++ b/app/resume.json
@@ -19,8 +19,8 @@
       "expires": "2026-05",
       "id": 3,
       "issued": "2023-05",
-      "issuer": "Amazon Web Services (AWS)",
-      "name": "AWS Certified Cloud Practitioner"
+      "issuer": "Microsoft",
+      "name": "AZ-900: Microsoft Azure Fundamentals"
     },
     {
       "credential_id": "438017330",
@@ -225,7 +225,7 @@
     {
       "bullets": [
         "Created an interactive lab using AI tools to build a resume-focused website.",
-        "Containerized the application with Docker and orchestrated it using Kubernetes.",
+        "Containerized the application with Docker and orchestrated it using Azure Kubernetes Service (AKS).",
         "Deployed the site to Azure for public access and scalability testing.",
         "This is that website!"
       ],


### PR DESCRIPTION
## Summary
- replace AWS certification with AZ-900 and emphasize Azure deployments in resume projects
- remove AWS references from filesystem view and mention Azure Kubernetes Service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c63a8220848322a8b7f45eb860d3ad