### PR TITLE
fix: restore CLI minigame and static resume pages

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -24,14 +24,10 @@
           <input id="command" autocomplete="off" autofocus />
         </form>
         <div id="hotkeys">
-          <button data-cmd="open overview" type="button">Overview</button>
-          <button data-cmd="open experience" type="button">Experience</button>
-          <button data-cmd="open projects" type="button">Projects</button>
-          <button data-cmd="open education" type="button">Education</button>
-          <!-- Certifications shortcut -->
-          <button data-cmd="open certifications" type="button">Certifications</button>
-          <button data-cmd="help" type="button">Help</button>
-          <button data-cmd="open secret" type="button">&gt;:(</button>
+          <button data-cmd="ls" type="button">ls</button>
+          <button data-cmd="pwd" type="button">pwd</button>
+          <button data-cmd="cd .." type="button">cd ..</button>
+          <button data-cmd="help" type="button">help</button>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- revive filesystem-based CLI minigame with ls, cd, pwd, and cat commands
- maintain resume navigation commands alongside new minigame
- update homepage hotkeys to surface minigame commands

## Testing
- `python -m pytest`
- `python - <<'PY'
from app.main import api_start, api_command, Command
start = api_start()
token = start['csrf_token']
print('token length', len(token))
print('ls:', api_command(Command(command='ls'), x_csrf_token=token)['text'].split('\n')[0])
print('cd projects:', api_command(Command(command='cd projects'), x_csrf_token=token)['text'].split('\n')[0])
print('pwd:', api_command(Command(command='pwd'), x_csrf_token=token)['text'])
print('cat about.txt:', api_command(Command(command='cat about.txt'), x_csrf_token=token)['text'][:20])
print('open overview:', api_command(Command(command='open overview'), x_csrf_token=token)['text'].split('\n')[0])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68c6a59e91d48322abe84d4eb695a053