### PR TITLE
Rename Interactive Resume Terminal

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Interactive Resume Terminal</title>
+  <title>Chad's Interactive Resume Terminal</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
@@ -16,7 +16,7 @@
     </nav>
   </header>
     <main class="centered">
-      <h1 class="cli-title">Interactive Resume Terminal</h1>
+      <h1 class="cli-title">Chad's Interactive Resume Terminal</h1>
       <div id="game-container">
         <div id="terminal"></div>
         <form id="command-form">


### PR DESCRIPTION
## Summary
- rename interactive terminal to "Chad's Interactive Resume Terminal"

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68c6b2140d3c83228157745b3bac9075