### PR TITLE
refactor: centralize navigation and clean up unused code

### DIFF
--- a/app/static/about.html
+++ b/app/static/about.html
@@ -6,15 +6,7 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <header>
-    <nav>
-      <a href="/">Home</a>
-      <a href="/resume">Resume</a>
-      <a href="/projects">Projects</a>
-      <a href="/education">Education</a>
-      <a href="/about">About</a>
-    </nav>
-  </header>
+  <header id="site-nav"></header>
   <main>
       <h1>About Me</h1>
       <div class="about-content">
@@ -29,5 +21,6 @@
   <footer>
     <p>&copy; 2024 Chad Lindemood</p>
   </footer>
+  <script src="/static/nav.js"></script>
   </body>
 </html>

--- a/app/static/education.html
+++ b/app/static/education.html
@@ -6,15 +6,7 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <header>
-    <nav>
-      <a href="/">Home</a>
-      <a href="/resume">Resume</a>
-      <a href="/projects">Projects</a>
-      <a href="/education">Education</a>
-      <a href="/about">About</a>
-    </nav>
-  </header>
+  <header id="site-nav"></header>
   <main>
     <h1>Education</h1>
     <ul id="education-list"></ul>
@@ -24,6 +16,7 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/nav.js"></script>
     <script type="module">
       import {loadEducation} from '/static/resume-data.js';
       loadEducation();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -6,15 +6,7 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <header>
-    <nav>
-      <a href="/">Home</a>
-      <a href="/resume">Resume</a>
-      <a href="/projects">Projects</a>
-      <a href="/education">Education</a>
-      <a href="/about">About</a>
-    </nav>
-  </header>
+  <header id="site-nav"></header>
     <main class="centered">
       <h1 class="cli-title">Chad's Interactive Resume Terminal</h1>
       <div id="game-container">
@@ -38,6 +30,7 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/nav.js"></script>
     <script src="/static/script.js"></script>
   </body>
 </html>

--- a/app/static/nav.html
+++ b/app/static/nav.html
@@ -1,0 +1,8 @@
+<nav>
+  <a href="/">Home</a>
+  <a href="/resume">Resume</a>
+  <a href="/projects">Projects</a>
+  <a href="/education">Education</a>
+  <a href="/about">About</a>
+</nav>
+

--- a/app/static/nav.js
+++ b/app/static/nav.js
@@ -1,0 +1,7 @@
+async function loadNav() {
+  const res = await fetch('/static/nav.html');
+  document.getElementById('site-nav').innerHTML = await res.text();
+}
+
+loadNav();
+

--- a/app/static/projects.html
+++ b/app/static/projects.html
@@ -6,15 +6,7 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <header>
-    <nav>
-      <a href="/">Home</a>
-      <a href="/resume">Resume</a>
-      <a href="/projects">Projects</a>
-      <a href="/education">Education</a>
-      <a href="/about">About</a>
-    </nav>
-  </header>
+  <header id="site-nav"></header>
   <main>
     <h1>Projects</h1>
     <ul id="projects-list"></ul>
@@ -22,6 +14,7 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/nav.js"></script>
     <script type="module">
       import {loadProjects} from '/static/resume-data.js';
       loadProjects();

--- a/app/static/resume-data.js
+++ b/app/static/resume-data.js
@@ -17,14 +17,6 @@ function formatDate(str, short = false) {
   return `${m}/${d}/${year}`;
 }
 
-export async function loadAbout() {
-  const r = await fetchResume();
-  const p = document.getElementById('about-text');
-  if (p) {
-    p.textContent = r.overview.summary;
-  }
-}
-
 export async function loadProjects() {
   const r = await fetchResume();
   const list = document.getElementById('projects-list');

--- a/app/static/resume.html
+++ b/app/static/resume.html
@@ -6,19 +6,12 @@
   <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
-  <header>
-    <nav>
-      <a href="/">Home</a>
-      <a href="/resume">Resume</a>
-      <a href="/projects">Projects</a>
-      <a href="/education">Education</a>
-      <a href="/about">About</a>
-    </nav>
-  </header>
+  <header id="site-nav"></header>
   <main id="resume-container"></main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/nav.js"></script>
     <script type="module">
       import {loadResume} from '/static/resume-data.js';
       loadResume();


### PR DESCRIPTION
## Summary
- load navigation markup from a shared template to cut duplication across pages
- remove unused `loadAbout` helper from resume-data

## Testing
- `node --check app/static/nav.js`
- `node --check app/static/resume-data.js`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6bc5ac5f88322a97cd53cf15d62b8