### PR TITLE
fix: handle utils import when run as script

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List
 
-from .utils import format_date, strip_scheme
+try:
+    from .utils import format_date, strip_scheme
+except ImportError:  # pragma: no cover - fallback for script execution
+    from utils import format_date, strip_scheme
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse


### PR DESCRIPTION
## Summary
- support running `app/main.py` directly by falling back to absolute import
- avoids ImportError when launching with a path such as `uvicorn main:app`

## Testing
- `pytest -q`
- `python app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6c1af43d48322b2221483d607f429