### PR TITLE
docs: use assigned port for Azure

### DIFF
--- a/AZURE_DEPLOYMENT.md
+++ b/AZURE_DEPLOYMENT.md
@@ -67,8 +67,10 @@ the FastAPI app:
 az webapp config set \
   --resource-group resume-site-rg \
   --name <unique-app-name> \
-  --startup-file "uvicorn app.main:app --host 0.0.0.0 --port 8000"
+  --startup-file "uvicorn app.main:app --host 0.0.0.0 --port $PORT"
 ```
+
+This command uses the `PORT` environment variable provided by App Service to choose the correct port.
 
 Add any required environment variables with `az webapp config appsettings set`.
 


### PR DESCRIPTION
## Summary
- clarify Azure App Service startup command to use the dynamically assigned PORT

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c73230e7908322a70c900dd76eb95a