### PR TITLE
Validate command requests with Pydantic

### DIFF
--- a/app/static/script.js
+++ b/app/static/script.js
@@ -60,6 +60,13 @@ async function sendCommand(cmd) {
   });
   const data = await res.json();
   print('$ ' + cmd, 'input');
+  if (!res.ok) {
+    const msg = Array.isArray(data.detail)
+      ? data.detail.map(d => d.msg).join(' ')
+      : 'Invalid input.';
+    print(msg, 'error');
+    return;
+  }
   if (data.clear) {
     terminal.textContent = '';
   }


### PR DESCRIPTION
## Summary
- Introduce `CommandRequest` Pydantic model to validate CLI commands.
- Update `/api/command` endpoint to use the model and strip command text.
- Handle validation errors in the frontend when the API returns 422.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c74c0cd5ac8322a69e6878c44c0622