### PR TITLE
Pin exact dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Core FastAPI app and ASGI server
-fastapi~=0.111.0
-uvicorn[standard]~=0.30.0
+fastapi==0.111.0
+uvicorn[standard]==0.30.0
 
 # Optional session store using Redis
-redis~=5.0.0
+redis==5.0.0
 
 # Async file access for serving static files
-aiofiles~=23.2.0
+aiofiles==23.2.0


### PR DESCRIPTION
## Summary
- pin FastAPI and related dependencies to exact versions

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python -m uvicorn app.main:app --port 8000 --log-level warning` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_68c74d02f2648322a88e2329a7129160