### PR TITLE
Run session cleanup more frequently

### DIFF
--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -1,0 +1,27 @@
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.main import SESSION_TTL, prune_sessions, sessions
+
+
+def test_prune_sessions_respects_ttl():
+    """Sessions younger than the TTL should not be removed."""
+
+    sessions.clear()
+
+    # Session older than the TTL should be pruned.
+    old_id = "old"
+    sessions[old_id] = {"_ts": time.time() - (SESSION_TTL + 1)}
+
+    # Session within the TTL should remain.
+    young_id = "young"
+    sessions[young_id] = {"_ts": time.time() - (SESSION_TTL - 1)}
+
+    prune_sessions(now=time.time())
+
+    assert old_id not in sessions
+    assert young_id in sessions
+


### PR DESCRIPTION
## Summary
- Run background session cleanup more frequently by sleeping `min(SESSION_TTL, 300)`
- Allow `prune_sessions` to accept a custom TTL and use `>=` comparison
- Add regression test ensuring sessions younger than the TTL are retained

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7541f6b7c8322a5d252b0f83e3c6b