### PR TITLE
Style CLI scrollbar to match terminal palette

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -127,6 +127,27 @@ main.centered {
   font-family: monospace;
   border: 1px solid var(--ibm-terminal-border);
   color: var(--ibm-terminal-text);
+  scrollbar-color: var(--ibm-terminal-secondary) var(--ibm-terminal-surface);
+}
+
+#terminal::-webkit-scrollbar {
+  width: 10px;
+}
+
+#terminal::-webkit-scrollbar-track {
+  background: var(--ibm-terminal-surface);
+  border-left: 1px solid rgba(0, 255, 0, 0.15);
+}
+
+#terminal::-webkit-scrollbar-thumb {
+  background: var(--ibm-terminal-secondary);
+  border-radius: 6px;
+  border: 1px solid var(--ibm-terminal-border);
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.35);
+}
+
+#terminal::-webkit-scrollbar-thumb:hover {
+  background: var(--ibm-terminal-text);
 }
 
 #terminal .input {


### PR DESCRIPTION
## Summary
- customize the CLI terminal scrollbar to use the IBM-inspired terminal color variables
- add hover and track styling so the scrollbar aligns with the retro green theme

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c88dea89b08322982d052ca5b901dc