### PR TITLE
Add light and dark theme toggle

### DIFF
--- a/app/static/about.html
+++ b/app/static/about.html
@@ -13,6 +13,10 @@
       <a href="/projects">Projects</a>
       <a href="/education">Education</a>
       <a href="/about">About</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false">
+        <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__text">Dark</span>
+      </button>
     </nav>
   </header>
   <main>
@@ -29,5 +33,6 @@
   <footer>
     <p>&copy; 2024 Chad Lindemood</p>
   </footer>
+  <script src="/static/theme.js"></script>
   </body>
 </html>

--- a/app/static/education.html
+++ b/app/static/education.html
@@ -13,6 +13,10 @@
       <a href="/projects">Projects</a>
       <a href="/education">Education</a>
       <a href="/about">About</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false">
+        <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__text">Dark</span>
+      </button>
     </nav>
   </header>
   <main>
@@ -24,6 +28,7 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/theme.js"></script>
     <script type="module">
       import {loadEducation} from '/static/resume-data.js';
       loadEducation();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -13,6 +13,10 @@
       <a href="/projects">Projects</a>
       <a href="/education">Education</a>
       <a href="/about">About</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false">
+        <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__text">Dark</span>
+      </button>
     </nav>
   </header>
     <main class="centered">
@@ -38,6 +42,7 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/theme.js"></script>
     <script src="/static/script.js"></script>
   </body>
 </html>

--- a/app/static/projects.html
+++ b/app/static/projects.html
@@ -13,6 +13,10 @@
       <a href="/projects">Projects</a>
       <a href="/education">Education</a>
       <a href="/about">About</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false">
+        <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__text">Dark</span>
+      </button>
     </nav>
   </header>
   <main>
@@ -22,6 +26,7 @@
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/theme.js"></script>
     <script type="module">
       import {loadProjects} from '/static/resume-data.js';
       loadProjects();

--- a/app/static/resume.html
+++ b/app/static/resume.html
@@ -13,12 +13,17 @@
       <a href="/projects">Projects</a>
       <a href="/education">Education</a>
       <a href="/about">About</a>
+      <button id="theme-toggle" class="theme-toggle" type="button" aria-label="Switch to dark theme" aria-pressed="false">
+        <span class="theme-toggle__icon" aria-hidden="true">🌙</span>
+        <span class="theme-toggle__text">Dark</span>
+      </button>
     </nav>
   </header>
   <main id="resume-container"></main>
     <footer>
       <p>&copy; 2024 Chad Lindemood</p>
     </footer>
+    <script src="/static/theme.js"></script>
     <script type="module">
       import {loadResume} from '/static/resume-data.js';
       loadResume();

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,46 +1,135 @@
 body {
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  background: #f5f7fa;
-  color: #333;
+  --body-bg: #f5f7fa;
+  --text-color: #333;
+  --heading-color: #2c3e50;
+  --header-bg: linear-gradient(135deg, #2c3e50, #4ca1af);
+  --header-text: #fff;
+  --header-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  --nav-link-color: #fff;
+  --nav-link-hover-bg: rgba(255, 255, 255, 0.15);
+  --nav-link-hover-color: #fff;
+  --card-bg: #fff;
+  --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  --link-color: #4ca1af;
+  --link-hover-color: #2c3e50;
+  --footer-bg: #2c3e50;
+  --footer-text: #fff;
+  --toggle-bg: rgba(255, 255, 255, 0.12);
+  --toggle-border: rgba(255, 255, 255, 0.45);
+  --toggle-text: #fff;
+  --toggle-hover-bg: rgba(255, 255, 255, 0.2);
+  --toggle-hover-border: rgba(255, 255, 255, 0.6);
+  --image-border: #ccc;
+  background: var(--body-bg);
+  color: var(--text-color);
   margin: 0;
   line-height: 1.6;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+body.light-theme {
+  color-scheme: light;
+}
+
+body.dark-theme {
+  color-scheme: dark;
+  --body-bg: #0f172a;
+  --text-color: #e2e8f0;
+  --heading-color: #f1f5f9;
+  --header-bg: linear-gradient(135deg, #0f172a, #1e3a8a);
+  --header-text: #e2e8f0;
+  --header-shadow: 0 2px 10px rgba(15, 23, 42, 0.6);
+  --nav-link-color: #e2e8f0;
+  --nav-link-hover-bg: rgba(148, 163, 184, 0.25);
+  --nav-link-hover-color: #fff;
+  --card-bg: #111827;
+  --card-shadow: 0 4px 24px rgba(2, 6, 23, 0.6);
+  --link-color: #38bdf8;
+  --link-hover-color: #bae6fd;
+  --footer-bg: #0f172a;
+  --footer-text: #e2e8f0;
+  --toggle-bg: rgba(148, 163, 184, 0.2);
+  --toggle-border: rgba(148, 163, 184, 0.4);
+  --toggle-text: #e2e8f0;
+  --toggle-hover-bg: rgba(148, 163, 184, 0.4);
+  --toggle-hover-border: rgba(148, 163, 184, 0.65);
+  --image-border: #334155;
 }
 
 header {
-  background: linear-gradient(135deg, #2c3e50, #4ca1af);
-  color: #fff;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  background: var(--header-bg);
+  color: var(--header-text);
+  box-shadow: var(--header-shadow);
   padding: 0.5rem 0;
+  transition: background 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
 }
 
 nav {
   display: flex;
   justify-content: center;
+  align-items: center;
   gap: 1rem;
   flex-wrap: wrap;
 }
 
 nav a {
-  color: #fff;
+  color: var(--nav-link-color);
   text-decoration: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;
-  transition: background 0.2s;
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-nav a:hover {
-  background: rgba(255, 255, 255, 0.15);
+nav a:hover,
+nav a:focus-visible {
+  background: var(--nav-link-hover-bg);
+  color: var(--nav-link-hover-color);
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--toggle-border);
+  background: var(--toggle-bg);
+  color: var(--toggle-text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.theme-toggle:hover {
+  background: var(--toggle-hover-bg);
+  border-color: var(--toggle-hover-border);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--link-color);
+  outline-offset: 2px;
+}
+
+.theme-toggle__icon {
+  font-size: 1.1rem;
+}
+
+.theme-toggle__text {
+  letter-spacing: 0.02em;
 }
 
 h1,
 h2,
 h3,
 h4 {
-  color: #2c3e50;
+  color: var(--heading-color);
   margin-top: 0;
+  transition: color 0.3s ease;
 }
 
 main {
@@ -48,36 +137,40 @@ main {
   width: 90%;
   max-width: 900px;
   margin: 2rem auto;
-  background: #fff;
+  background: var(--card-bg);
+  color: inherit;
   padding: 2rem;
   border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--card-shadow);
+  transition: background-color 0.3s ease, color 0.3s ease, box-shadow 0.3s ease;
 }
 
 a {
-  color: #4ca1af;
+  color: var(--link-color);
   text-decoration: none;
+  transition: color 0.2s ease;
 }
 
-a:hover {
-  color: #2c3e50;
+a:hover,
+a:focus {
+  color: var(--link-hover-color);
   text-decoration: underline;
 }
 
 main.centered {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    background: none;
-    box-shadow: none;
-    margin: 0.5rem auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background: none;
+  box-shadow: none;
+  margin: 0.5rem auto;
 }
 
 .cli-title {
   margin: 0 0 1rem 0;
   font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  color: #2c3e50;
+  color: var(--heading-color);
   background: none;
   padding: 0;
   border: none;
@@ -242,16 +335,17 @@ main.centered {
 .headshot {
   width: 400px;
   height: 400px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--image-border);
   object-fit: cover;
   flex-shrink: 0;
   margin-top: 1rem;
 }
 
 footer {
-  background: #2c3e50;
-  color: #fff;
+  background: var(--footer-bg);
+  color: var(--footer-text);
   text-align: center;
   padding: 1rem 0;
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 

--- a/app/static/theme.js
+++ b/app/static/theme.js
@@ -1,0 +1,77 @@
+(function () {
+  const storageKey = 'preferred-theme';
+  const toggle = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (!toggle || !body) {
+    return;
+  }
+
+  const icon = toggle.querySelector('.theme-toggle__icon');
+  const text = toggle.querySelector('.theme-toggle__text');
+  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+
+  const readStoredTheme = () => {
+    try {
+      return localStorage.getItem(storageKey);
+    } catch (err) {
+      return null;
+    }
+  };
+
+  const storeTheme = theme => {
+    try {
+      localStorage.setItem(storageKey, theme);
+    } catch (err) {
+      /* ignore write errors */
+    }
+  };
+
+  const updateToggleContent = theme => {
+    if (icon) {
+      icon.textContent = theme === 'dark' ? '☀️' : '🌙';
+    }
+    if (text) {
+      text.textContent = theme === 'dark' ? 'Light' : 'Dark';
+    }
+    toggle.setAttribute('aria-label', theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme');
+    toggle.setAttribute('aria-pressed', theme === 'dark' ? 'true' : 'false');
+  };
+
+  const applyTheme = theme => {
+    const normalized = theme === 'dark' ? 'dark' : 'light';
+    body.classList.remove('light-theme', 'dark-theme');
+    body.classList.add(`${normalized}-theme`);
+    updateToggleContent(normalized);
+  };
+
+  const getPreferredTheme = () => {
+    const stored = readStoredTheme();
+    if (stored === 'light' || stored === 'dark') {
+      return stored;
+    }
+    return mediaQuery.matches ? 'dark' : 'light';
+  };
+
+  applyTheme(getPreferredTheme());
+
+  toggle.addEventListener('click', () => {
+    const isDark = body.classList.contains('dark-theme');
+    const nextTheme = isDark ? 'light' : 'dark';
+    applyTheme(nextTheme);
+    storeTheme(nextTheme);
+  });
+
+  const handlePreferenceChange = event => {
+    if (readStoredTheme()) {
+      return;
+    }
+    applyTheme(event.matches ? 'dark' : 'light');
+  };
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handlePreferenceChange);
+  } else if (typeof mediaQuery.addListener === 'function') {
+    mediaQuery.addListener(handlePreferenceChange);
+  }
+})();


### PR DESCRIPTION
## Summary
- restyle shared layout using theme variables and add dark theme values alongside the existing light palette
- add a reusable navigation toggle and supporting script that persists the selected theme and reacts to system preference changes
- load the new toggle and script on each static page so the theme can be switched anywhere on the site

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8926182348322a34fc806530091a7